### PR TITLE
Codex/day 01 repo standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ pnpm dev
 
 Then open [http://localhost:3000](http://localhost:3000).
 
+## Validation Scripts
+
+Use the repository scripts below as the canonical local validation entrypoints:
+
+```bash
+zsh scripts/lint.sh
+zsh scripts/build.sh
+zsh scripts/test.sh
+zsh scripts/check.sh
+```
+
+`scripts/check.sh` runs the full local delivery sequence in the same order expected for a review branch.
+
+## Delivery Workflow
+
+Daily milestone work ships on review branches named `codex/day-XX-<slug>`, never directly on `main`. The full branch, review, and merge rules live in [docs/delivery-workflow.md](./docs/delivery-workflow.md).
+
 ## NVIDIA API Setup
 
 To enable live AI card generation, create a local `.env.local` file with:

--- a/docs/delivery-workflow.md
+++ b/docs/delivery-workflow.md
@@ -1,0 +1,38 @@
+# Delivery Workflow
+
+## Purpose
+
+This repository ships the 15-day Attention Regain MVP in small reviewable increments. The workflow below keeps daily milestone work, review, and validation consistent.
+
+## Branching Rules
+
+- Do not work directly on `main`.
+- Start each scheduled day task from the latest `main`.
+- Use the review branch format `codex/day-XX-<slug>`.
+- Finish the lowest-numbered open day before touching later milestones.
+- Within the active day, take the lowest-numbered open child issue first unless GitHub marks it blocked.
+
+## Delivery Loop
+
+1. Confirm the active day milestone and child issue from GitHub.
+2. Create a review branch for that issue.
+3. Implement the issue end to end before moving to another child issue.
+4. Run the local validation commands.
+5. Push the branch and request review before merge.
+
+## Local Validation Commands
+
+Use the repository scripts as the canonical local entrypoints:
+
+- `zsh scripts/lint.sh` runs repository hygiene checks from `scripts/lint.mjs`.
+- `zsh scripts/build.sh` runs the production Next.js build through `pnpm build`.
+- `zsh scripts/test.sh` runs the repository contract smoke tests in `tests/`.
+- `zsh scripts/check.sh` runs the full local delivery sequence in order.
+
+## Commit And Review Expectations
+
+- Keep commits scoped and coherent.
+- Use commit messages in the format `<type>(day-XX): add|update|remove <path>`.
+- Prefer per-file commits when a change touches multiple concerns.
+- Merge only after the review branch passes the required local checks.
+- Close the child issue only after the acceptance criteria are met and validation passes.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+pnpm build

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+zsh scripts/lint.sh
+zsh scripts/build.sh
+zsh scripts/test.sh

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,0 +1,105 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const DIRECTORIES = ["src", "docs", "scripts", "tests"];
+const ROOT_FILES = ["README.md", "package.json"];
+const TEXT_EXTENSIONS = new Set([".css", ".js", ".json", ".md", ".mjs"]);
+const REQUIRED_SCRIPT_FILES = [
+  "scripts/lint.sh",
+  "scripts/build.sh",
+  "scripts/test.sh",
+  "scripts/check.sh",
+];
+
+const issues = [];
+
+async function main() {
+  const files = new Set();
+
+  for (const file of ROOT_FILES) {
+    files.add(path.join(ROOT, file));
+  }
+
+  for (const directory of DIRECTORIES) {
+    await collectFiles(path.join(ROOT, directory), files);
+  }
+
+  for (const file of Array.from(files).sort()) {
+    await lintFile(file);
+  }
+
+  await lintRepositoryScripts();
+
+  if (issues.length) {
+    for (const issue of issues) {
+      console.error(issue);
+    }
+    console.error(`lint failed with ${issues.length} issue(s).`);
+    process.exit(1);
+  }
+
+  console.log(`lint passed for ${files.size} file(s).`);
+}
+
+async function collectFiles(directory, files) {
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        await collectFiles(fullPath, files);
+        continue;
+      }
+
+      if (TEXT_EXTENSIONS.has(path.extname(entry.name))) {
+        files.add(fullPath);
+      }
+    }
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
+}
+
+async function lintFile(file) {
+  const relativePath = path.relative(ROOT, file);
+  const contents = await readFile(file, "utf8");
+  const lines = contents.split("\n");
+
+  lines.forEach((line, index) => {
+    if (line.includes("\t")) {
+      issues.push(`${relativePath}:${index + 1} contains a tab character.`);
+    }
+
+    if (/[ \t]+$/.test(line)) {
+      issues.push(`${relativePath}:${index + 1} has trailing whitespace.`);
+    }
+  });
+
+  if (!contents.endsWith("\n")) {
+    issues.push(`${relativePath} is missing a trailing newline.`);
+  }
+}
+
+async function lintRepositoryScripts() {
+  for (const relativePath of REQUIRED_SCRIPT_FILES) {
+    try {
+      await readFile(path.join(ROOT, relativePath), "utf8");
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        issues.push(`${relativePath} is missing.`);
+        continue;
+      }
+
+      throw error;
+    }
+  }
+}
+
+await main();

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+node scripts/lint.mjs

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+node --test tests/*.test.mjs

--- a/tests/workflow-contract.test.mjs
+++ b/tests/workflow-contract.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { access, readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("delivery scripts are present and discoverable", async () => {
+  await access(new URL("../scripts/lint.sh", import.meta.url));
+  await access(new URL("../scripts/build.sh", import.meta.url));
+  await access(new URL("../scripts/test.sh", import.meta.url));
+  await access(new URL("../scripts/check.sh", import.meta.url));
+});
+
+test("workflow docs define branch and delivery expectations", async () => {
+  const readme = await readFile(new URL("../README.md", import.meta.url), "utf8");
+  const workflowDoc = await readFile(
+    new URL("../docs/delivery-workflow.md", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(readme, /scripts\/check\.sh/);
+  assert.match(workflowDoc, /codex\/day-XX-<slug>/);
+  assert.match(workflowDoc, /lowest-numbered open child issue first/);
+  assert.match(workflowDoc, /Do not work directly on `main`\./);
+});


### PR DESCRIPTION
Earliest incomplete day from GitHub is still Day 01 (#1). I completed the lowest-numbered actionable child issue, #17 Day 01.1, on branch codex/day-01-repo-standards and pushed it to origin.

The work adds the delivery workflow baseline in docs/delivery-workflow.md, updates README.md to surface the workflow and validation entrypoints, and adds repo-local validation scripts plus a contract smoke test under scripts and workflow-contract.test.mjs.

Validation passed with preflight.sh, zsh scripts/check.sh, and lockfile-guard.sh. Issue and milestone state did not change because GitHub write operations are blocked by the stored token scope: both commenting on and closing #17 returned 403 Resource not accessible by personal access token. The next expected issue is #18 Day 01.2 - Add environment contract and configuration validation.