### PR TITLE
Day 5/reliable pdf parsing 20260422 1711

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The input is a paper, notes, or another reading source. The output is a mobile-f
 
 - Next.js App Router frontend in a single page file
 - Paste-text and PDF upload intake
-- Server-side PDF text extraction with `pdf-parse`
+- Server-side PDF text extraction with page references and explicit OCR-needed
+  failure states
 - Source-grounded feed generation for:
   - quick-read cards
   - recall prompts
@@ -77,6 +78,7 @@ The app now uses NVIDIA's OpenAI-compatible chat completions endpoint and falls 
 - `src/app/globals.css`
 - `src/app/page.js`
 - `src/app/api/study-feed/route.js`
+- `src/lib/documents/pdf-parser.js`
 - `README.md`
 
 ## Product Boundary

--- a/db/migrations/0003_document_parse_outputs.sql
+++ b/db/migrations/0003_document_parse_outputs.sql
@@ -1,0 +1,62 @@
+-- Day 05 reliable PDF parsing and source references.
+-- Parsed pages and diagnostics stay owner-reachable through documents.
+
+ALTER TABLE documents
+  DROP CONSTRAINT IF EXISTS documents_status_check;
+
+ALTER TABLE documents
+  ADD CONSTRAINT documents_status_check CHECK (
+    status IN (
+      'draft',
+      'uploaded',
+      'parsed',
+      'chunked',
+      'cards_generated',
+      'ocr_needed',
+      'parse_failed',
+      'failed'
+    )
+  );
+
+ALTER TABLE documents
+  ADD COLUMN IF NOT EXISTS page_count INTEGER NOT NULL DEFAULT 0 CHECK (page_count >= 0),
+  ADD COLUMN IF NOT EXISTS parse_status TEXT CHECK (
+    parse_status IN ('parsed', 'ocr_needed', 'parse_failed')
+  );
+
+ALTER TABLE document_chunks
+  ADD COLUMN IF NOT EXISTS page_number INTEGER CHECK (page_number > 0);
+
+CREATE TABLE document_pages (
+  id TEXT PRIMARY KEY,
+  document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  page_number INTEGER NOT NULL CHECK (page_number > 0),
+  citation TEXT NOT NULL,
+  text TEXT NOT NULL,
+  word_count INTEGER NOT NULL DEFAULT 0 CHECK (word_count >= 0),
+  character_count INTEGER NOT NULL DEFAULT 0 CHECK (character_count >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (document_id, page_number)
+);
+
+CREATE TABLE document_parse_diagnostics (
+  id TEXT PRIMARY KEY,
+  document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  status TEXT NOT NULL CHECK (status IN ('parsed', 'ocr_needed', 'parse_failed')),
+  code TEXT NOT NULL,
+  parser TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  page_count INTEGER NOT NULL DEFAULT 0 CHECK (page_count >= 0),
+  pages_with_text INTEGER NOT NULL DEFAULT 0 CHECK (pages_with_text >= 0),
+  word_count INTEGER NOT NULL DEFAULT 0 CHECK (word_count >= 0),
+  character_count INTEGER NOT NULL DEFAULT 0 CHECK (character_count >= 0),
+  average_page_chars INTEGER NOT NULL DEFAULT 0 CHECK (average_page_chars >= 0),
+  warnings_json TEXT NOT NULL DEFAULT '[]',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX document_pages_document_page_idx
+  ON document_pages(document_id, page_number);
+
+CREATE INDEX document_parse_diagnostics_document_created_idx
+  ON document_parse_diagnostics(document_id, created_at DESC);

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -32,6 +32,7 @@ Fields:
 
 - `id`, `user_id`, `title`, `source_kind`, `source_ref`
 - `goal`, `status`, `content_hash`, `word_count`
+- `page_count`, `parse_status`
 - `created_at`, `updated_at`, `parsed_at`, `failed_at`
 - `failure_reason`
 
@@ -55,6 +56,18 @@ Stores normalized source slices used for retrieval and grounded generation.
 Chunks belong to one document and include stable citation text such as `Page 2`.
 Embedding vectors are planned for the hosted adapter; the initial migration keeps
 provider metadata and vector status separate from the chunk text.
+
+### document_pages
+
+Stores normalized extracted text per source page. Page rows are queryable by
+`document_id` and `page_number`, retain their citation label, and provide the
+source text boundary that downstream retrieval can cite.
+
+### document_parse_diagnostics
+
+Records parser outcomes for normal, scanned-like, and failed PDFs. Diagnostics
+store parser name, explicit status, machine-readable code, page counts, text
+signal counts, and warnings so failure states can be shown without guessing.
 
 ### study_sessions
 
@@ -83,7 +96,9 @@ Document status:
 3. `parsed` when readable text has been extracted.
 4. `chunked` when source chunks have been stored.
 5. `cards_generated` when at least one grounded card is persisted.
-6. `failed` when parsing, chunking, or generation cannot complete.
+6. `ocr_needed` when the PDF has pages but too little extractable text.
+7. `parse_failed` when the parser cannot read the PDF structure.
+8. `failed` when chunking or generation cannot complete after parsing.
 
 Session status:
 
@@ -125,6 +140,14 @@ Migration `0002_document_uploads.sql` creates:
 - unique S3 bucket/object-key traceability
 - upload lifecycle indexes for owner-scoped queries
 
+Migration `0003_document_parse_outputs.sql` adds:
+
+- explicit `ocr_needed` and `parse_failed` document states
+- `page_count` and `parse_status` fields on documents
+- `page_number` on document chunks for page-aware retrieval
+- `document_pages` for citation-ready page text
+- `document_parse_diagnostics` for parse signal and failure explanations
+
 Rollout order:
 
 1. Create owner table and document tables.
@@ -134,6 +157,7 @@ Rollout order:
 5. Create interactions after sessions and cards.
 6. Add indexes for user dashboards, latest session lookup, and source retrieval.
 7. Add upload metadata after the core document table exists.
+8. Add parse outputs before background OCR and retrieval workers.
 
 Rollback expectation: Day 03 migrations are reversible before production data is
 loaded. After real user data exists, rollback should be a forward migration that
@@ -159,6 +183,7 @@ Repository responsibilities:
 
 - Generate public resource IDs.
 - Store documents, chunks, sessions, cards, and interactions.
+- Store extracted page text and parser diagnostics before generation.
 - Return only rows owned by the authenticated user.
 - Keep local JSON storage and future Postgres storage behind the same service
   boundary.

--- a/docs/pdf-parsing.md
+++ b/docs/pdf-parsing.md
@@ -1,0 +1,49 @@
+# PDF Parsing Contract
+
+Day 05 makes PDF extraction a backend contract instead of route-local helper
+code. The parser runs only in the Node.js server runtime, extracts page-level
+text, and records explicit diagnostics before cards are generated.
+
+## Flow
+
+1. Validate the upload descriptor as a PDF or text source.
+2. Parse PDFs with `pdf-parse` on the server.
+3. Normalize extracted text and page records.
+4. Assess parse signal before retrieval or generation.
+5. Persist parsed page text and diagnostics for uploaded documents.
+6. Generate passages and cards only from readable source text.
+
+## Parse States
+
+- `parsed`: readable text was extracted and page references are available.
+- `ocr_needed`: the PDF has no text or too little text signal for grounded
+  generation; scanned and image-heavy files land here.
+- `parse_failed`: the PDF parser could not read the document structure.
+
+The API returns the explicit parse state and diagnostic code for failures.
+When the request is tied to a private upload record, the same state is persisted
+on the document and the upload is marked failed unless it has already been
+consumed.
+
+## Stored Output
+
+- `documents.page_count` and `documents.parse_status` summarize the latest parse.
+- `document_pages` stores normalized page text and citation labels.
+- `document_parse_diagnostics` stores parser name, status, code, counts, and
+  warnings for debugging and user-facing failure messages.
+- `document_chunks.page_number` keeps generated passages aligned with source
+  pages for retrieval and citations.
+
+## Regression Coverage
+
+The parser tests cover:
+
+- a stable generated text PDF fixture with page-level extraction
+- empty and low-signal parse heuristics
+- invalid PDF parser failures
+- repository persistence for page rows and diagnostics
+- API failure responses for unreadable uploaded PDFs
+
+The local fixture test also exercises `/Users/work/Downloads/AIAYN.pdf`,
+`/Users/work/Downloads/SAM.pdf`, and `/Users/work/Downloads/OPUS.pdf` when those
+files are present on the machine.

--- a/src/app/api/study-feed/route.js
+++ b/src/app/api/study-feed/route.js
@@ -1,4 +1,3 @@
-import { PDFParse } from "pdf-parse";
 import { getEnvironmentReport } from "../../../lib/env.js";
 import {
   readProductSessionFromCookieHeader,
@@ -6,6 +5,11 @@ import {
 } from "../../../lib/auth/session.server.js";
 import { requestHasSameOrigin } from "../../../lib/auth/request.js";
 import { getDefaultStudyRepository } from "../../../lib/data/repositories.js";
+import {
+  extractPdfFile,
+  normalizeExtractedText,
+  PDF_PARSE_STATUSES,
+} from "../../../lib/documents/pdf-parser.js";
 import { validateUploadDescriptor } from "../../../lib/uploads/validation.js";
 
 export const runtime = "nodejs";
@@ -92,6 +96,7 @@ export async function POST(request) {
     let sourceText = pastedText;
     let sourceKind = "paste";
     let pageRefs = [];
+    let parseResult = null;
     let resolvedTitle = title;
 
     if (uploadDocumentId) {
@@ -118,6 +123,27 @@ export async function POST(request) {
       }
 
       const extracted = await extractFile(uploaded);
+      if (!extracted.ok) {
+        if (uploadDocumentId) {
+          await repository.markDocumentParseFailed({
+            userId: session.user.id,
+            documentId: uploadDocumentId,
+            status: extracted.status,
+            failureReason: extracted.error,
+            diagnostics: extracted.diagnostics,
+          });
+        }
+        return Response.json(
+          {
+            error: extracted.error,
+            code: extracted.code,
+            parse: buildParseResponse(extracted),
+          },
+          { status: extracted.status === PDF_PARSE_STATUSES.PARSE_FAILED ? 400 : 422 },
+        );
+      }
+
+      parseResult = extracted;
       sourceText = extracted.text;
       sourceKind = extracted.sourceKind;
       pageRefs = extracted.pages;
@@ -133,9 +159,24 @@ export async function POST(request) {
     }
 
     const pages = pageRefs.length ? pageRefs.map((page) => ({
-      num: page.num,
+      pageNumber: page.pageNumber || page.num,
+      num: page.pageNumber || page.num,
+      citation: page.citation || `Page ${page.pageNumber || page.num}`,
       text: sanitize(page.text),
+      wordCount: page.wordCount,
+      characterCount: page.characterCount,
     })) : createPseudoPages(sourceText);
+
+    if (uploadDocumentId && parseResult) {
+      await repository.saveParsedDocument({
+        userId: session.user.id,
+        documentId: uploadDocumentId,
+        text: sourceText,
+        pages,
+        diagnostics: parseResult.diagnostics,
+      });
+    }
+
     const passages = createPassages(pages);
     const wordCount = sourceText.split(/\s+/).filter(Boolean).length;
     const baseDeck = {
@@ -145,6 +186,9 @@ export async function POST(request) {
       stats: {
         estimatedMinutes: Math.max(4, Math.round(wordCount / 180)),
         chunkCount: passages.length,
+        parseStatus: parseResult?.status,
+        pageCount: parseResult?.diagnostics?.pageCount || pages.length,
+        extractedWordCount: parseResult?.diagnostics?.wordCount || wordCount,
       },
     };
 
@@ -318,7 +362,7 @@ async function persistDeck({
     documentTitle: payload.documentTitle,
     goal: payload.goal,
     sourceKind: payload.sourceKind,
-    sourceRef: payload.documentTitle,
+    sourceRef: payload.sourceRef || payload.documentTitle,
     passages,
     focusTags: payload.focusTags,
     cards: payload.cards,
@@ -334,46 +378,57 @@ async function persistDeck({
   };
 }
 
+function buildParseResponse(result) {
+  return {
+    status: result.status,
+    code: result.code,
+    pageCount: result.diagnostics?.pageCount || 0,
+    pagesWithText: result.diagnostics?.pagesWithText || 0,
+    wordCount: result.diagnostics?.wordCount || 0,
+    reason: result.diagnostics?.reason || result.error,
+  };
+}
+
 async function extractFile(file) {
   const extension = file.name.split(".").pop()?.toLowerCase() || "";
   const title = file.name.replace(/\.[^.]+$/, "");
 
   if (file.type === "application/pdf" || extension === "pdf") {
-    return extractPdf(file, title);
+    return extractPdfFile(file, { title });
   }
 
-  const text = await file.text();
+  const text = normalizeExtractedText(await file.text());
+  const pages = text
+    .split(/\n{2,}/)
+    .map((block, index) => ({
+      pageNumber: index + 1,
+      citation: `Section ${index + 1}`,
+      text: block,
+      wordCount: block.split(/\s+/).filter(Boolean).length,
+      characterCount: block.length,
+    }))
+    .filter((page) => page.text.trim());
   return {
+    ok: true,
+    status: "parsed",
+    code: "readable_text",
     title,
     text,
-    pages: text
-      .split(/\n{2,}/)
-      .map((block, index) => ({
-        num: index + 1,
-        text: block,
-      }))
-      .filter((page) => page.text.trim()),
+    pages,
+    diagnostics: {
+      parser: "plain-text",
+      status: "parsed",
+      code: "readable_text",
+      reason: "Readable text file was normalized into source sections.",
+      pageCount: pages.length || 1,
+      pagesWithText: pages.length,
+      wordCount: text.split(/\s+/).filter(Boolean).length,
+      characterCount: text.length,
+      averagePageChars: pages.length ? Math.round(text.length / pages.length) : text.length,
+      warnings: [],
+    },
     sourceKind: "file",
   };
-}
-
-async function extractPdf(file, title) {
-  const data = new Uint8Array(await file.arrayBuffer());
-  const parser = new PDFParse({ data });
-
-  try {
-    const result = await parser.getText();
-    return {
-      title,
-      text: result.text,
-      pages: result.pages
-        .map((page) => ({ num: page.num, text: page.text }))
-        .filter((page) => page.text.trim()),
-      sourceKind: "pdf",
-    };
-  } finally {
-    await parser.destroy();
-  }
 }
 
 async function generateDeckWithNvidia({ documentTitle, goal, passages, apiKey, model }) {
@@ -495,7 +550,7 @@ function createPseudoPages(text) {
   for (const block of blocks) {
     const next = current ? `${current}\n\n${block}` : block;
     if (next.length > 1500 && current) {
-      pages.push({ num: pageNum, text: current });
+      pages.push({ pageNumber: pageNum, num: pageNum, citation: `Section ${pageNum}`, text: current });
       pageNum += 1;
       current = block;
       continue;
@@ -504,16 +559,20 @@ function createPseudoPages(text) {
   }
 
   if (current) {
-    pages.push({ num: pageNum, text: current });
+    pages.push({ pageNumber: pageNum, num: pageNum, citation: `Section ${pageNum}`, text: current });
   }
 
-  return pages.length ? pages : [{ num: 1, text }];
+  return pages.length
+    ? pages
+    : [{ pageNumber: 1, num: 1, citation: "Section 1", text }];
 }
 
 function createPassages(pages) {
   const passages = [];
 
   for (const page of pages) {
+    const pageNumber = page.pageNumber || page.num || passages.length + 1;
+    const citation = page.citation || `Page ${pageNumber}`;
     const chunks = page.text
       .split(/\n{2,}/)
       .flatMap(splitLongBlock)
@@ -528,7 +587,8 @@ function createPassages(pages) {
       passages.push({
         text: chunk,
         sentences,
-        citation: `Page ${page.num}`,
+        citation,
+        pageNumber,
         topics: extractTopics(chunk),
       });
 

--- a/src/lib/data/repositories.js
+++ b/src/lib/data/repositories.js
@@ -19,6 +19,15 @@ export function createStudyRepository({ store = createLocalJsonStore() } = {}) {
     getDocumentUploadForUser(userId, documentId) {
       return getDocumentUploadForUser(store, userId, documentId);
     },
+    saveParsedDocument(input) {
+      return saveParsedDocument(store, input);
+    },
+    markDocumentParseFailed(input) {
+      return markDocumentParseFailed(store, input);
+    },
+    getDocumentParseForUser(userId, documentId) {
+      return getDocumentParseForUser(store, userId, documentId);
+    },
     saveGeneratedDeck(input) {
       return saveGeneratedDeck(store, input);
     },
@@ -148,6 +157,175 @@ async function getDocumentUploadForUser(store, userId, documentId) {
   ) || null;
 }
 
+async function saveParsedDocument(store, input) {
+  const userId = requireNonEmpty(input.userId, "userId");
+  const documentId = requireNonEmpty(input.documentId, "documentId");
+  const timestamp = nowIso();
+  const text = String(input.text || "");
+  const pages = normalizePageInputs(input.pages);
+  const diagnostics = normalizeDiagnostics(input.diagnostics, "parsed");
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+  let parsedDocument = null;
+
+  await store.update((current) => {
+    const existingDocument = current.documents.find(
+      (entry) => entry.id === documentId && entry.userId === userId,
+    );
+    if (!existingDocument) {
+      throw new Error("Document upload was not found for this user.");
+    }
+
+    parsedDocument = {
+      ...existingDocument,
+      status: "parsed",
+      contentHash: hashSourceText(text),
+      wordCount,
+      pageCount: pages.length,
+      parseStatus: "parsed",
+      updatedAt: timestamp,
+      parsedAt: timestamp,
+      failedAt: null,
+      failureReason: "",
+    };
+
+    return {
+      ...current,
+      documents: current.documents.map((document) =>
+        document.id === documentId && document.userId === userId ? parsedDocument : document,
+      ),
+      documentPages: [
+        ...current.documentPages.filter((page) => page.documentId !== documentId),
+        ...pages.map((page) => ({
+          id: createPublicId("page"),
+          documentId,
+          pageNumber: page.pageNumber,
+          citation: page.citation || `Page ${page.pageNumber}`,
+          text: page.text,
+          wordCount: page.wordCount,
+          characterCount: page.characterCount,
+          createdAt: timestamp,
+        })),
+      ],
+      documentParseDiagnostics: [
+        ...current.documentParseDiagnostics.filter(
+          (entry) => entry.documentId !== documentId || entry.status !== "parsed",
+        ),
+        {
+          id: createPublicId("parse"),
+          documentId,
+          status: "parsed",
+          code: diagnostics.code,
+          parser: diagnostics.parser,
+          reason: diagnostics.reason,
+          pageCount: diagnostics.pageCount,
+          pagesWithText: diagnostics.pagesWithText,
+          wordCount: diagnostics.wordCount,
+          characterCount: diagnostics.characterCount,
+          averagePageChars: diagnostics.averagePageChars,
+          warnings: diagnostics.warnings,
+          createdAt: timestamp,
+        },
+      ],
+    };
+  });
+
+  return parsedDocument;
+}
+
+async function markDocumentParseFailed(store, input) {
+  const userId = requireNonEmpty(input.userId, "userId");
+  const documentId = requireNonEmpty(input.documentId, "documentId");
+  const status = requireNonEmpty(input.status, "status");
+  assertAllowedValue("parse", status);
+  if (status === "parsed") {
+    throw new Error("Parsed documents must be saved through saveParsedDocument.");
+  }
+
+  const timestamp = nowIso();
+  const diagnostics = normalizeDiagnostics(input.diagnostics, status);
+  let failedDocument = null;
+
+  await store.update((current) => {
+    const existingDocument = current.documents.find(
+      (entry) => entry.id === documentId && entry.userId === userId,
+    );
+    if (!existingDocument) {
+      throw new Error("Document upload was not found for this user.");
+    }
+
+    const failureReason = String(input.failureReason || diagnostics.reason || status);
+    failedDocument = {
+      ...existingDocument,
+      status,
+      pageCount: diagnostics.pageCount,
+      parseStatus: status,
+      updatedAt: timestamp,
+      failedAt: timestamp,
+      failureReason,
+    };
+
+    return {
+      ...current,
+      documents: current.documents.map((document) =>
+        document.id === documentId && document.userId === userId ? failedDocument : document,
+      ),
+      documentUploads: current.documentUploads.map((upload) =>
+        upload.documentId === documentId && upload.userId === userId && upload.status !== "consumed"
+          ? {
+              ...upload,
+              status: "failed",
+              updatedAt: timestamp,
+              failedAt: timestamp,
+              failureReason,
+            }
+          : upload,
+      ),
+      documentParseDiagnostics: [
+        ...current.documentParseDiagnostics,
+        {
+          id: createPublicId("parse"),
+          documentId,
+          status,
+          code: diagnostics.code,
+          parser: diagnostics.parser,
+          reason: diagnostics.reason,
+          pageCount: diagnostics.pageCount,
+          pagesWithText: diagnostics.pagesWithText,
+          wordCount: diagnostics.wordCount,
+          characterCount: diagnostics.characterCount,
+          averagePageChars: diagnostics.averagePageChars,
+          warnings: diagnostics.warnings,
+          createdAt: timestamp,
+        },
+      ],
+    };
+  });
+
+  return failedDocument;
+}
+
+async function getDocumentParseForUser(store, userId, documentId) {
+  const ownerId = requireNonEmpty(userId, "userId");
+  const targetDocumentId = requireNonEmpty(documentId, "documentId");
+  const current = await store.read();
+  const document = current.documents.find(
+    (entry) => entry.id === targetDocumentId && entry.userId === ownerId,
+  );
+  if (!document) {
+    return null;
+  }
+
+  return {
+    document,
+    pages: current.documentPages
+      .filter((page) => page.documentId === targetDocumentId)
+      .sort((left, right) => left.pageNumber - right.pageNumber),
+    diagnostics: current.documentParseDiagnostics
+      .filter((entry) => entry.documentId === targetDocumentId)
+      .sort((left, right) => String(left.createdAt).localeCompare(String(right.createdAt))),
+  };
+}
+
 async function saveGeneratedDeck(store, input) {
   const userId = requireNonEmpty(input.user?.id, "user.id");
   const title = requireNonEmpty(input.documentTitle, "documentTitle");
@@ -169,11 +347,15 @@ async function saveGeneratedDeck(store, input) {
   const sessionId = createPublicId("session");
   const chunkRows = passages.map((passage, index) => {
     const text = String(passage.text || "");
+    const pageNumber = Number.isSafeInteger(passage.pageNumber)
+      ? passage.pageNumber
+      : extractPageNumber(passage.citation);
     return {
       id: createPublicId("chunk"),
       documentId,
       sequence: index,
       citation: String(passage.citation || `Section ${index + 1}`),
+      pageNumber,
       text,
       topics: Array.isArray(passage.topics) ? passage.topics.map(String) : [],
       tokenEstimate: estimateTokens(text),
@@ -241,6 +423,8 @@ async function saveGeneratedDeck(store, input) {
       status: "cards_generated",
       contentHash: hashSourceText(sourceText),
       wordCount: sourceText.split(/\s+/).filter(Boolean).length,
+      pageCount: existingDocument?.pageCount || countDistinctPageNumbers(chunkRows),
+      parseStatus: existingDocument?.parseStatus || "parsed",
       createdAt: existingDocument?.createdAt || timestamp,
       updatedAt: timestamp,
       parsedAt: timestamp,
@@ -447,6 +631,65 @@ function markConsumedUploadRows(rows, documentId, userId, timestamp) {
       consumedAt: timestamp,
     };
   });
+}
+
+function normalizePageInputs(pages = []) {
+  return (Array.isArray(pages) ? pages : [])
+    .map((page, index) => {
+      const pageNumber = Number.isSafeInteger(page?.pageNumber)
+        ? page.pageNumber
+        : Number.isSafeInteger(page?.num)
+          ? page.num
+          : index + 1;
+      const text = String(page?.text || "").trim();
+      return {
+        pageNumber,
+        citation: String(page?.citation || `Page ${pageNumber}`),
+        text,
+        wordCount: Number.isSafeInteger(page?.wordCount)
+          ? page.wordCount
+          : text.split(/\s+/).filter(Boolean).length,
+        characterCount: Number.isSafeInteger(page?.characterCount)
+          ? page.characterCount
+          : text.length,
+      };
+    })
+    .filter((page) => page.text);
+}
+
+function normalizeDiagnostics(diagnostics = {}, fallbackStatus) {
+  const status = typeof diagnostics.status === "string" ? diagnostics.status : fallbackStatus;
+  assertAllowedValue("parse", status);
+  return {
+    parser: typeof diagnostics.parser === "string" ? diagnostics.parser : "pdf-parse",
+    status,
+    code: typeof diagnostics.code === "string" ? diagnostics.code : status,
+    reason: typeof diagnostics.reason === "string" ? diagnostics.reason : status,
+    pageCount: Number.isSafeInteger(diagnostics.pageCount) ? diagnostics.pageCount : 0,
+    pagesWithText: Number.isSafeInteger(diagnostics.pagesWithText) ? diagnostics.pagesWithText : 0,
+    wordCount: Number.isSafeInteger(diagnostics.wordCount) ? diagnostics.wordCount : 0,
+    characterCount: Number.isSafeInteger(diagnostics.characterCount)
+      ? diagnostics.characterCount
+      : 0,
+    averagePageChars: Number.isSafeInteger(diagnostics.averagePageChars)
+      ? diagnostics.averagePageChars
+      : 0,
+    warnings: Array.isArray(diagnostics.warnings) ? diagnostics.warnings.map(String) : [],
+  };
+}
+
+function extractPageNumber(citation) {
+  const match = String(citation || "").match(/\bPage\s+(\d+)\b/i);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function countDistinctPageNumbers(rows) {
+  const pageNumbers = new Set(
+    rows
+      .map((row) => row.pageNumber)
+      .filter((pageNumber) => Number.isSafeInteger(pageNumber)),
+  );
+  return pageNumbers.size;
 }
 
 function requireNonEmpty(value, label) {

--- a/src/lib/data/schema.js
+++ b/src/lib/data/schema.js
@@ -9,8 +9,11 @@ export const DOCUMENT_STATUSES = Object.freeze([
   "parsed",
   "chunked",
   "cards_generated",
+  "ocr_needed",
+  "parse_failed",
   "failed",
 ]);
+export const PARSE_STATUSES = Object.freeze(["parsed", "ocr_needed", "parse_failed"]);
 export const SESSION_STATUSES = Object.freeze(["building", "ready", "archived", "failed"]);
 export const CARD_STATUSES = Object.freeze(["active", "saved", "dismissed"]);
 export const UPLOAD_STATUSES = Object.freeze([
@@ -30,6 +33,7 @@ export const INTERACTION_TYPES = Object.freeze([
 const STATUS_SETS = {
   sourceKind: new Set(SOURCE_KINDS),
   document: new Set(DOCUMENT_STATUSES),
+  parse: new Set(PARSE_STATUSES),
   session: new Set(SESSION_STATUSES),
   card: new Set(CARD_STATUSES),
   upload: new Set(UPLOAD_STATUSES),
@@ -71,6 +75,10 @@ export function normalizeJsonStore(input = {}) {
     users: Array.isArray(input.users) ? input.users : [],
     documents: Array.isArray(input.documents) ? input.documents : [],
     documentUploads: Array.isArray(input.documentUploads) ? input.documentUploads : [],
+    documentPages: Array.isArray(input.documentPages) ? input.documentPages : [],
+    documentParseDiagnostics: Array.isArray(input.documentParseDiagnostics)
+      ? input.documentParseDiagnostics
+      : [],
     documentChunks: Array.isArray(input.documentChunks) ? input.documentChunks : [],
     studySessions: Array.isArray(input.studySessions) ? input.studySessions : [],
     studyCards: Array.isArray(input.studyCards) ? input.studyCards : [],
@@ -84,6 +92,14 @@ export function createEmptyJsonStore() {
     migrations: [
       {
         id: "0001_core_schema",
+        appliedAt: nowIso(),
+      },
+      {
+        id: "0002_document_uploads",
+        appliedAt: nowIso(),
+      },
+      {
+        id: "0003_document_parse_outputs",
         appliedAt: nowIso(),
       },
     ],

--- a/src/lib/documents/pdf-parser.js
+++ b/src/lib/documents/pdf-parser.js
@@ -1,0 +1,212 @@
+import { PDFParse } from "pdf-parse";
+
+export const PDF_PARSE_STATUSES = Object.freeze({
+  PARSED: "parsed",
+  OCR_NEEDED: "ocr_needed",
+  PARSE_FAILED: "parse_failed",
+});
+
+export const PDF_PARSE_CODES = Object.freeze({
+  READABLE_TEXT: "readable_text",
+  EMPTY_TEXT: "empty_text",
+  LOW_TEXT_SIGNAL: "low_text_signal",
+  SCANNED_OR_IMAGE_HEAVY: "scanned_or_image_heavy",
+  PARSER_ERROR: "parser_error",
+});
+
+const MIN_READABLE_WORDS = 18;
+const MIN_READABLE_CHARS = 120;
+const MIN_AVERAGE_PAGE_CHARS = 45;
+const MAX_EXTRACTED_CHARS = 80_000;
+
+export async function extractPdfFile(file, { title = "" } = {}) {
+  const resolvedTitle = title || inferTitleFromFile(file);
+  const data = new Uint8Array(await file.arrayBuffer());
+  const parser = new PDFParse({ data });
+
+  try {
+    const result = await parser.getText();
+    const pages = normalizePdfPages(result.pages);
+    const text = normalizeExtractedText(
+      pages.length ? pages.map((page) => page.text).join("\n\n") : result.text,
+    );
+    const diagnostics = assessPdfParseSignal({
+      text,
+      pages,
+      pageCount: Number.isSafeInteger(result.total) ? result.total : pages.length,
+    });
+
+    if (diagnostics.status !== PDF_PARSE_STATUSES.PARSED) {
+      return {
+        ok: false,
+        status: diagnostics.status,
+        code: diagnostics.code,
+        error: buildParseFailureMessage(diagnostics),
+        title: resolvedTitle,
+        text,
+        pages,
+        diagnostics,
+        sourceKind: "pdf",
+      };
+    }
+
+    return {
+      ok: true,
+      status: PDF_PARSE_STATUSES.PARSED,
+      code: PDF_PARSE_CODES.READABLE_TEXT,
+      title: resolvedTitle,
+      text,
+      pages,
+      diagnostics,
+      sourceKind: "pdf",
+    };
+  } catch (error) {
+    const diagnostics = buildParserErrorDiagnostics(error);
+    return {
+      ok: false,
+      status: PDF_PARSE_STATUSES.PARSE_FAILED,
+      code: PDF_PARSE_CODES.PARSER_ERROR,
+      error: buildParseFailureMessage(diagnostics),
+      title: resolvedTitle,
+      text: "",
+      pages: [],
+      diagnostics,
+      sourceKind: "pdf",
+    };
+  } finally {
+    await parser.destroy();
+  }
+}
+
+export function normalizeExtractedText(text) {
+  return String(text || "")
+    .replace(/\r/g, "\n")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+    .slice(0, MAX_EXTRACTED_CHARS);
+}
+
+export function assessPdfParseSignal({ text = "", pages = [], pageCount = 0 } = {}) {
+  const normalizedText = normalizeExtractedText(text);
+  const normalizedPages = normalizePdfPages(pages);
+  const wordCount = countWords(normalizedText);
+  const characterCount = normalizedText.length;
+  const detectedPageCount = Math.max(
+    Number.isSafeInteger(pageCount) ? pageCount : 0,
+    normalizedPages.length,
+  );
+  const pagesWithText = normalizedPages.filter((page) => countWords(page.text) > 0).length;
+  const averagePageChars = detectedPageCount
+    ? Math.round(characterCount / detectedPageCount)
+    : characterCount;
+  const warnings = [];
+
+  if (!characterCount || !wordCount) {
+    warnings.push("The parser returned no readable text.");
+    return {
+      parser: "pdf-parse",
+      status: PDF_PARSE_STATUSES.OCR_NEEDED,
+      code: detectedPageCount ? PDF_PARSE_CODES.SCANNED_OR_IMAGE_HEAVY : PDF_PARSE_CODES.EMPTY_TEXT,
+      reason: detectedPageCount
+        ? "The PDF has pages but no extractable text, which usually means scanned or image-heavy content."
+        : "The PDF parser returned no text and no page records.",
+      pageCount: detectedPageCount,
+      pagesWithText,
+      wordCount,
+      characterCount,
+      averagePageChars,
+      warnings,
+    };
+  }
+
+  if (wordCount < MIN_READABLE_WORDS || characterCount < MIN_READABLE_CHARS) {
+    warnings.push("The extracted text is too short for grounded card generation.");
+  }
+  if (detectedPageCount > 0 && averagePageChars < MIN_AVERAGE_PAGE_CHARS) {
+    warnings.push("The average text per page is below the readable-PDF threshold.");
+  }
+
+  if (warnings.length) {
+    return {
+      parser: "pdf-parse",
+      status: PDF_PARSE_STATUSES.OCR_NEEDED,
+      code: PDF_PARSE_CODES.LOW_TEXT_SIGNAL,
+      reason: warnings.join(" "),
+      pageCount: detectedPageCount,
+      pagesWithText,
+      wordCount,
+      characterCount,
+      averagePageChars,
+      warnings,
+    };
+  }
+
+  return {
+    parser: "pdf-parse",
+    status: PDF_PARSE_STATUSES.PARSED,
+    code: PDF_PARSE_CODES.READABLE_TEXT,
+    reason: "Readable text was extracted with page-level source references.",
+    pageCount: detectedPageCount || normalizedPages.length || 1,
+    pagesWithText,
+    wordCount,
+    characterCount,
+    averagePageChars,
+    warnings,
+  };
+}
+
+export function normalizePdfPages(pages = []) {
+  return (Array.isArray(pages) ? pages : [])
+    .map((page, index) => {
+      const pageNumber = Number.isSafeInteger(page?.pageNumber)
+        ? page.pageNumber
+        : Number.isSafeInteger(page?.num)
+          ? page.num
+          : index + 1;
+      const text = normalizeExtractedText(page?.text || "");
+
+      return {
+        pageNumber,
+        citation: `Page ${pageNumber}`,
+        text,
+        wordCount: countWords(text),
+        characterCount: text.length,
+      };
+    })
+    .filter((page) => page.text);
+}
+
+export function buildParseFailureMessage(diagnostics) {
+  if (diagnostics.status === PDF_PARSE_STATUSES.PARSE_FAILED) {
+    return "The PDF could not be parsed. Try another copy or export the document as text.";
+  }
+  if (diagnostics.code === PDF_PARSE_CODES.SCANNED_OR_IMAGE_HEAVY) {
+    return "This PDF looks scanned or image-heavy. OCR is needed before grounded cards can be generated.";
+  }
+  return "The PDF did not contain enough readable text for grounded cards. OCR may be needed.";
+}
+
+function buildParserErrorDiagnostics(error) {
+  return {
+    parser: "pdf-parse",
+    status: PDF_PARSE_STATUSES.PARSE_FAILED,
+    code: PDF_PARSE_CODES.PARSER_ERROR,
+    reason: error instanceof Error ? error.message : "The PDF parser failed.",
+    pageCount: 0,
+    pagesWithText: 0,
+    wordCount: 0,
+    characterCount: 0,
+    averagePageChars: 0,
+    warnings: ["The parser threw before returning page-level text."],
+  };
+}
+
+function inferTitleFromFile(file) {
+  const name = typeof file?.name === "string" ? file.name : "";
+  return name.replace(/\.[^.]+$/, "") || "Untitled PDF";
+}
+
+function countWords(text) {
+  return String(text || "").split(/\s+/).filter(Boolean).length;
+}

--- a/tests/data-layer-contract.test.mjs
+++ b/tests/data-layer-contract.test.mjs
@@ -21,6 +21,8 @@ test("Day 03 documentation defines entities, status transitions, and boundaries"
     "study_sessions",
     "study_cards",
     "study_interactions",
+    "document_pages",
+    "document_parse_diagnostics",
     "Status Transitions",
     "Repository Boundaries",
     "Rollback expectation",

--- a/tests/fixture-pdfs.test.mjs
+++ b/tests/fixture-pdfs.test.mjs
@@ -74,9 +74,12 @@ test("local PDF fixtures generate grounded fallback decks when available", async
 
         assert.equal(response.status, 200);
         assert.equal(payload.generationMode, "fallback");
+        assert.equal(payload.stats.parseStatus, "parsed");
+        assert.ok(payload.stats.pageCount > 0);
+        assert.ok(payload.stats.extractedWordCount > 0);
         assert.ok(Array.isArray(payload.cards));
         assert.ok(payload.cards.length > 0);
-        assert.ok(payload.cards.every((card) => typeof card.citation === "string" && card.citation));
+        assert.ok(payload.cards.every((card) => /^Page \d+/.test(card.citation)));
       });
     }
   } finally {

--- a/tests/pdf-parser-contract.test.mjs
+++ b/tests/pdf-parser-contract.test.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createAuthenticatedProductSession,
+  serializeProductSession,
+} from "../src/lib/auth/session-shared.js";
+import { createLocalJsonStore } from "../src/lib/data/local-store.js";
+import { createStudyRepository } from "../src/lib/data/repositories.js";
+import {
+  assessPdfParseSignal,
+  extractPdfFile,
+  PDF_PARSE_CODES,
+  PDF_PARSE_STATUSES,
+} from "../src/lib/documents/pdf-parser.js";
+
+test("Day 05 documentation and migration define parse outputs and states", async () => {
+  const doc = await readFile(new URL("../docs/pdf-parsing.md", import.meta.url), "utf8");
+  const migration = await readFile(
+    new URL("../db/migrations/0003_document_parse_outputs.sql", import.meta.url),
+    "utf8",
+  );
+
+  for (const expected of [
+    "document_pages",
+    "document_parse_diagnostics",
+    "ocr_needed",
+    "parse_failed",
+    "page_number",
+  ]) {
+    assert.match(doc, new RegExp(expected));
+    assert.match(migration, new RegExp(expected));
+  }
+});
+
+test("PDF parser extracts citation-ready page text from a stable fixture", async () => {
+  const file = new File([createTextPdfFixture()], "parser-fixture.pdf", {
+    type: "application/pdf",
+  });
+
+  const result = await extractPdfFile(file);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, PDF_PARSE_STATUSES.PARSED);
+  assert.equal(result.pages.length, 1);
+  assert.equal(result.pages[0].pageNumber, 1);
+  assert.equal(result.pages[0].citation, "Page 1");
+  assert.match(result.text, /Retrieval practice helps learners rebuild attention/);
+  assert.equal(result.diagnostics.code, PDF_PARSE_CODES.READABLE_TEXT);
+  assert.ok(result.diagnostics.wordCount >= 18);
+});
+
+test("PDF parser separates low-signal and unreadable PDFs from normal flow", async () => {
+  const scannedLike = assessPdfParseSignal({
+    text: "",
+    pages: [],
+    pageCount: 3,
+  });
+  const lowSignal = assessPdfParseSignal({
+    text: "Figure 1.",
+    pages: [{ pageNumber: 1, text: "Figure 1." }],
+    pageCount: 1,
+  });
+  const invalid = await extractPdfFile(
+    new File([new Uint8Array([1, 2, 3, 4])], "broken.pdf", { type: "application/pdf" }),
+  );
+
+  assert.equal(scannedLike.status, PDF_PARSE_STATUSES.OCR_NEEDED);
+  assert.equal(scannedLike.code, PDF_PARSE_CODES.SCANNED_OR_IMAGE_HEAVY);
+  assert.equal(lowSignal.status, PDF_PARSE_STATUSES.OCR_NEEDED);
+  assert.equal(lowSignal.code, PDF_PARSE_CODES.LOW_TEXT_SIGNAL);
+  assert.equal(invalid.ok, false);
+  assert.equal(invalid.status, PDF_PARSE_STATUSES.PARSE_FAILED);
+});
+
+test("repository persists parsed pages and diagnostics for uploaded documents", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "attention-regain-parse-"));
+  const store = createLocalJsonStore({ dataDir });
+  const repository = createStudyRepository({ store });
+
+  try {
+    const upload = await repository.createDocumentUpload({
+      user: { id: "reader-1", email: "reader@example.com" },
+      documentId: "doc_parse_contract",
+      title: "Parser contract",
+      goal: "study parser boundaries",
+      sourceKind: "pdf",
+      file: {
+        fileName: "contract.pdf",
+        contentType: "application/pdf",
+        sizeBytes: 512,
+      },
+      storage: {
+        provider: "s3",
+        bucket: "local-private-documents",
+        objectKey: "private/users/hash/documents/doc_parse_contract/source/contract.pdf",
+        objectUri: "s3://local-private-documents/private/users/hash/documents/doc_parse_contract/source/contract.pdf",
+        uploadMode: "metadata-only",
+      },
+    });
+
+    await repository.saveParsedDocument({
+      userId: "reader-1",
+      documentId: upload.documentId,
+      text: "Retrieval practice asks the learner to rebuild the source before rereading.",
+      pages: [
+        {
+          pageNumber: 1,
+          citation: "Page 1",
+          text: "Retrieval practice asks the learner to rebuild the source before rereading.",
+        },
+      ],
+      diagnostics: {
+        parser: "pdf-parse",
+        status: "parsed",
+        code: "readable_text",
+        reason: "Readable text was extracted.",
+        pageCount: 1,
+        pagesWithText: 1,
+        wordCount: 11,
+        characterCount: 76,
+        averagePageChars: 76,
+        warnings: [],
+      },
+    });
+
+    const parsed = await repository.getDocumentParseForUser("reader-1", upload.documentId);
+    assert.equal(parsed.document.status, "parsed");
+    assert.equal(parsed.document.parseStatus, "parsed");
+    assert.equal(parsed.pages.length, 1);
+    assert.equal(parsed.pages[0].citation, "Page 1");
+    assert.equal(parsed.diagnostics.length, 1);
+    assert.equal(parsed.diagnostics[0].code, "readable_text");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("study feed route returns explicit parse failure contracts", async () => {
+  const previousDataDir = process.env.ATTENTION_REGAIN_DATA_DIR;
+  const previousEnableLiveGeneration = process.env.ENABLE_LIVE_GENERATION;
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "attention-regain-parse-route-"));
+  process.env.ATTENTION_REGAIN_DATA_DIR = dataDir;
+  process.env.ENABLE_LIVE_GENERATION = "false";
+
+  try {
+    const { POST } = await import("../src/app/api/study-feed/route.js");
+    const sessionCookie = serializeProductSession(
+      createAuthenticatedProductSession({
+        userId: "parse-route-reader",
+        email: "reader@example.com",
+        displayName: "Reader",
+        source: "test",
+      }),
+    );
+    const formData = new FormData();
+    formData.set(
+      "file",
+      new File([new Uint8Array([1, 2, 3, 4])], "broken.pdf", {
+        type: "application/pdf",
+      }),
+    );
+
+    const response = await POST(
+      new Request("http://localhost/api/study-feed", {
+        method: "POST",
+        body: formData,
+        headers: {
+          cookie: `attention_regain_session=${sessionCookie}`,
+        },
+      }),
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.parse.status, PDF_PARSE_STATUSES.PARSE_FAILED);
+    assert.equal(payload.parse.code, PDF_PARSE_CODES.PARSER_ERROR);
+  } finally {
+    if (typeof previousDataDir === "string") {
+      process.env.ATTENTION_REGAIN_DATA_DIR = previousDataDir;
+    } else {
+      delete process.env.ATTENTION_REGAIN_DATA_DIR;
+    }
+    if (typeof previousEnableLiveGeneration === "string") {
+      process.env.ENABLE_LIVE_GENERATION = previousEnableLiveGeneration;
+    } else {
+      delete process.env.ENABLE_LIVE_GENERATION;
+    }
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+function createTextPdfFixture() {
+  const content = [
+    "BT",
+    "/F1 14 Tf",
+    "72 720 Td",
+    `(${escapePdfText("Retrieval practice helps learners rebuild attention from source evidence.")}) Tj`,
+    "0 -22 Td",
+    `(${escapePdfText("Page citations keep every generated card tied to a source page.")}) Tj`,
+    "0 -22 Td",
+    `(${escapePdfText("Diagnostics explain whether a PDF needs OCR before generation.")}) Tj`,
+    "ET",
+  ].join("\n");
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    `<< /Length ${Buffer.byteLength(content, "utf8")} >>\nstream\n${content}\nendstream`,
+  ];
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+
+  objects.forEach((object, index) => {
+    offsets.push(Buffer.byteLength(pdf, "utf8"));
+    pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+
+  const xrefOffset = Buffer.byteLength(pdf, "utf8");
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += "0000000000 65535 f \n";
+  offsets.slice(1).forEach((offset) => {
+    pdf += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  });
+  pdf += `trailer\n<< /Root 1 0 R /Size ${objects.length + 1} >>\n`;
+  pdf += `startxref\n${xrefOffset}\n%%EOF\n`;
+
+  return new TextEncoder().encode(pdf);
+}
+
+function escapePdfText(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+}


### PR DESCRIPTION
## Day 05 — Complete and Ready for Review

**Branch pushed:** `day-5/reliable-pdf-parsing-20260422-1711` at `537e1a5`

### Implemented

- **Server-only PDF parser with page references:**
  [`src/lib/documents/pdf-parser.js`](/Users/work/Desktop/learning/Attention_regain/src/lib/documents/pdf-parser.js)
- **Parse persistence and explicit `ocr_needed` / `parse_failed` states:**
  [`src/lib/data/repositories.js`](/Users/work/Desktop/learning/Attention_regain/src/lib/data/repositories.js)
- **Day 05 migration for pages and diagnostics:**
  [`db/migrations/0003_document_parse_outputs.sql`](/Users/work/Desktop/learning/Attention_regain/db/migrations/0003_document_parse_outputs.sql)
- **Parser docs and regression tests:**
  [`docs/pdf-parsing.md`](/Users/work/Desktop/learning/Attention_regain/docs/pdf-parsing.md),
  [`tests/pdf-parser-contract.test.mjs`](/Users/work/Desktop/learning/Attention_regain/tests/pdf-parser-contract.test.mjs)

### Validation

Passed: `pnpm build`, `bash scripts/check.sh`, `node --test tests/*.test.mjs`, `lockfile-guard.sh`, plus private upload/feed smoke checks with `AIAYN.pdf`, `SAM.pdf`, and `OPUS.pdf`.

> `pnpm lint` and `pnpm test` were not run because `package.json` does not define those scripts; `bash scripts/check.sh` ran the repo lint and test scripts directly.

### GitHub State

- Child issues **#33–#36** closed
- Parent **#5** closed
- Milestone **#6** closed
- Next scheduled issue from GitHub is **#37** (Day 06.1)

> Retrieval/reranking were not validated because the current app does not implement those stages yet.