### PR TITLE
Day 7/chunking retrieval baseline 20260424 2103

### DIFF
--- a/db/migrations/0005_chunk_retrieval_metadata.sql
+++ b/db/migrations/0005_chunk_retrieval_metadata.sql
@@ -1,0 +1,19 @@
+-- Day 07 chunking and retrieval baseline.
+-- Chunks become stable page/paragraph source units before generation.
+
+ALTER TABLE document_chunks
+  ADD COLUMN IF NOT EXISTS section_label TEXT,
+  ADD COLUMN IF NOT EXISTS paragraph_start INTEGER CHECK (paragraph_start > 0),
+  ADD COLUMN IF NOT EXISTS paragraph_end INTEGER CHECK (paragraph_end > 0),
+  ADD COLUMN IF NOT EXISTS word_count INTEGER NOT NULL DEFAULT 0 CHECK (word_count >= 0),
+  ADD COLUMN IF NOT EXISTS character_count INTEGER NOT NULL DEFAULT 0 CHECK (character_count >= 0),
+  ADD COLUMN IF NOT EXISTS retrieval_rank INTEGER CHECK (retrieval_rank > 0),
+  ADD COLUMN IF NOT EXISTS retrieval_score REAL CHECK (retrieval_score >= 0),
+  ADD COLUMN IF NOT EXISTS retrieval_reason TEXT;
+
+CREATE INDEX IF NOT EXISTS document_chunks_document_page_paragraph_idx
+  ON document_chunks(document_id, page_number, paragraph_start, sequence);
+
+CREATE INDEX IF NOT EXISTS document_chunks_document_retrieval_idx
+  ON document_chunks(document_id, retrieval_rank)
+  WHERE retrieval_rank IS NOT NULL;

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -53,9 +53,12 @@ Statuses:
 ### document_chunks
 
 Stores normalized source slices used for retrieval and grounded generation.
-Chunks belong to one document and include stable citation text such as `Page 2`.
-Embedding vectors are planned for the hosted adapter; the initial migration keeps
-provider metadata and vector status separate from the chunk text.
+Chunks belong to one document and include stable citation text such as
+`Page 2, paragraphs 3-4`. They also store page number, section label,
+paragraph range, sequence, text counts, topic hints, retrieval rank, retrieval
+score, and retrieval reason. Embedding vectors are planned for the hosted
+adapter; the current local baseline keeps provider metadata and vector status
+separate from chunk text while deterministic retrieval selects generation input.
 
 ### document_pages
 
@@ -162,6 +165,13 @@ Migration `0004_document_processing_jobs.sql` adds:
 - `document_processing_jobs` for queue payloads, retries, and dead-letter state
 - lease metadata so a worker can recover stalled jobs
 
+Migration `0005_chunk_retrieval_metadata.sql` adds:
+
+- section and paragraph metadata on chunks
+- text counts for retrieval tuning and regression checks
+- retrieval rank, score, and reason fields for selected generation chunks
+- indexes for page/paragraph and retrieval-ranked chunk lookups
+
 Rollout order:
 
 1. Create owner table and document tables.
@@ -173,6 +183,7 @@ Rollout order:
 7. Add upload metadata after the core document table exists.
 8. Add parse outputs before background OCR and retrieval workers.
 9. Add background job rows before async worker orchestration ships.
+10. Add chunk retrieval metadata before grounded generation hardening.
 
 Rollback expectation: Day 03 migrations are reversible before production data is
 loaded. After real user data exists, rollback should be a forward migration that

--- a/docs/retrieval-baseline.md
+++ b/docs/retrieval-baseline.md
@@ -1,0 +1,45 @@
+# Chunking And Retrieval Baseline
+
+Day 07 stores source chunks before card generation so every generated card can
+point back to a stable source unit.
+
+## Chunking Rules
+
+- Chunks are built page by page and preserve source order with a zero-based
+  `sequence`.
+- Blank-line separated paragraphs are the primary boundaries.
+- Short adjacent paragraphs are merged until the chunk reaches the target size.
+- Oversized paragraphs are split on sentence boundaries.
+- Each chunk carries `pageNumber`, `sectionLabel`, `paragraphStart`,
+  `paragraphEnd`, `citation`, token estimate, text counts, and topics.
+
+Citation format:
+
+- One paragraph: `Page 2, paragraph 4`
+- Paragraph range: `Page 2, paragraphs 4-6`
+
+## Retrieval Strategy
+
+For small documents, every chunk is sent to generation. For larger documents,
+the baseline retriever scores chunks against the document title and study goal
+using deterministic keyword overlap, topic matches, and a small early-source
+position boost. Selected chunks are sorted back into source order before
+generation so cards remain readable and citations are predictable.
+
+When the query has too little signal or no chunk clears the confidence floor, the
+retriever falls back to an even spread across the document. This keeps large
+documents from silently depending on the opening pages while still avoiding a
+full-context prompt.
+
+## Tuning Notes
+
+- `minChunkChars` keeps single short paragraphs from becoming noisy standalone
+  cards.
+- `targetChunkChars` keeps chunks compact enough for prompt stability.
+- `maxChunkChars` prevents very long paragraphs from dominating retrieval.
+- `maxRetrievedChunks` caps generation context and should move with model
+  context budget, latency, and card quality observations.
+
+Embedding fields remain on `document_chunks` for the hosted retrieval worker.
+The local MVP marks chunks as pending and uses lexical retrieval until an
+embedding service is wired in.

--- a/src/lib/data/repositories.js
+++ b/src/lib/data/repositories.js
@@ -31,6 +31,9 @@ export function createStudyRepository({ store = createLocalJsonStore() } = {}) {
     getDocumentParseForUser(userId, documentId) {
       return getDocumentParseForUser(store, userId, documentId);
     },
+    saveDocumentChunks(input) {
+      return saveDocumentChunks(store, input);
+    },
     enqueueDocumentProcessingJob(input) {
       return enqueueDocumentProcessingJob(store, input);
     },
@@ -391,6 +394,52 @@ async function getDocumentParseForUser(store, userId, documentId) {
   };
 }
 
+async function saveDocumentChunks(store, input) {
+  const userId = requireNonEmpty(input.userId, "userId");
+  const documentId = requireNonEmpty(input.documentId, "documentId");
+  const chunks = Array.isArray(input.chunks) ? input.chunks : [];
+  if (!chunks.length) {
+    throw new Error("A parsed document needs at least one source chunk.");
+  }
+
+  const timestamp = nowIso();
+  const chunkRows = chunks.map((chunk, index) => normalizeChunkRow({
+    chunk,
+    documentId,
+    sequence: Number.isSafeInteger(chunk?.sequence) ? chunk.sequence : index,
+    timestamp,
+  }));
+  let persistedChunks = [];
+
+  await store.update((current) => {
+    const existingDocument = current.documents.find(
+      (entry) => entry.id === documentId && entry.userId === userId,
+    );
+    if (!existingDocument) {
+      throw new Error("Document upload was not found for this user.");
+    }
+
+    persistedChunks = chunkRows;
+    return {
+      ...current,
+      documents: current.documents.map((document) =>
+        document.id === documentId && document.userId === userId
+          ? {
+              ...document,
+              status: "chunked",
+              updatedAt: timestamp,
+            }
+          : document),
+      documentChunks: [
+        ...current.documentChunks.filter((chunk) => chunk.documentId !== documentId),
+        ...chunkRows,
+      ],
+    };
+  });
+
+  return persistedChunks;
+}
+
 async function enqueueDocumentProcessingJob(store, input) {
   const userId = requireNonEmpty(input.userId, "userId");
   const documentId = requireNonEmpty(input.documentId, "documentId");
@@ -627,26 +676,12 @@ async function saveGeneratedDeck(store, input) {
       : "";
   const documentId = requestedDocumentId || createPublicId("doc");
   const sessionId = createPublicId("session");
-  const chunkRows = passages.map((passage, index) => {
-    const text = String(passage.text || "");
-    const pageNumber = Number.isSafeInteger(passage.pageNumber)
-      ? passage.pageNumber
-      : extractPageNumber(passage.citation);
-    return {
-      id: createPublicId("chunk"),
-      documentId,
-      sequence: index,
-      citation: String(passage.citation || `Section ${index + 1}`),
-      pageNumber,
-      text,
-      topics: Array.isArray(passage.topics) ? passage.topics.map(String) : [],
-      tokenEstimate: estimateTokens(text),
-      embeddingStatus: "pending",
-      embeddingProvider: "",
-      embeddingModel: "",
-      createdAt: timestamp,
-    };
-  });
+  const chunkRows = passages.map((passage, index) => normalizeChunkRow({
+    chunk: passage,
+    documentId,
+    sequence: Number.isSafeInteger(passage?.sequence) ? passage.sequence : index,
+    timestamp,
+  }));
   const chunkByCitation = new Map(chunkRows.map((chunk) => [chunk.citation, chunk]));
   const cardRows = cards.map((card, index) => {
     const kind = ["glance", "recall", "application", "pitfall"].includes(card.kind)
@@ -703,13 +738,15 @@ async function saveGeneratedDeck(store, input) {
         (typeof input.sourceRef === "string" ? input.sourceRef : ""),
       goal,
       status: "cards_generated",
-      contentHash: hashSourceText(sourceText),
-      wordCount: sourceText.split(/\s+/).filter(Boolean).length,
+      contentHash: existingDocument?.contentHash || hashSourceText(sourceText),
+      wordCount:
+        existingDocument?.wordCount ||
+        sourceText.split(/\s+/).filter(Boolean).length,
       pageCount: existingDocument?.pageCount || countDistinctPageNumbers(chunkRows),
       parseStatus: existingDocument?.parseStatus || "parsed",
       createdAt: existingDocument?.createdAt || timestamp,
       updatedAt: timestamp,
-      parsedAt: timestamp,
+      parsedAt: existingDocument?.parsedAt || timestamp,
       failedAt: null,
       failureReason: "",
     };
@@ -744,7 +781,7 @@ async function saveGeneratedDeck(store, input) {
         userId,
         timestamp,
       ),
-      documentChunks: [...current.documentChunks, ...chunkRows],
+      documentChunks: mergeDeckChunks(current.documentChunks, chunkRows),
       studySessions: [...current.studySessions, sessionRow],
       studyCards: [...current.studyCards, ...cardRows],
     };
@@ -875,6 +912,7 @@ function buildDeckResponse({ document, session, cards }) {
       answer: card.answer || undefined,
       excerpt: card.excerpt,
       citation: card.citation,
+      chunkId: card.chunkId || undefined,
       status: card.status,
     })),
     generationMode: session.generationMode,
@@ -986,6 +1024,80 @@ function markConsumedUploadRows(rows, documentId, userId, timestamp) {
       consumedAt: timestamp,
     };
   });
+}
+
+function mergeDeckChunks(existingRows, deckRows) {
+  const deckById = new Map(deckRows.map((row) => [row.id, row]));
+  const mergedRows = existingRows.map((row) => {
+    const deckRow = deckById.get(row.id);
+    if (!deckRow) {
+      return row;
+    }
+
+    return {
+      ...row,
+      retrievalRank: deckRow.retrievalRank,
+      retrievalScore: deckRow.retrievalScore,
+      retrievalReason: deckRow.retrievalReason,
+      retrieval: deckRow.retrieval,
+    };
+  });
+  const existingIds = new Set(existingRows.map((row) => row.id));
+  const newRows = deckRows.filter((row) => !existingIds.has(row.id));
+  return [...mergedRows, ...newRows];
+}
+
+function normalizeChunkRow({ chunk, documentId, sequence, timestamp }) {
+  const text = String(chunk?.text || "").trim();
+  const citation = String(chunk?.citation || `Section ${sequence + 1}`).trim();
+  const pageNumber = Number.isSafeInteger(chunk?.pageNumber)
+    ? chunk.pageNumber
+    : extractPageNumber(citation);
+
+  return {
+    id: typeof chunk?.id === "string" && chunk.id.trim()
+      ? chunk.id.trim()
+      : createPublicId("chunk"),
+    documentId,
+    sequence,
+    citation,
+    pageNumber,
+    sectionLabel: typeof chunk?.sectionLabel === "string" ? chunk.sectionLabel : "",
+    paragraphStart: Number.isSafeInteger(chunk?.paragraphStart)
+      ? chunk.paragraphStart
+      : null,
+    paragraphEnd: Number.isSafeInteger(chunk?.paragraphEnd) ? chunk.paragraphEnd : null,
+    text,
+    sentences: Array.isArray(chunk?.sentences) ? chunk.sentences.map(String) : [],
+    topics: Array.isArray(chunk?.topics) ? chunk.topics.map(String) : [],
+    wordCount: Number.isSafeInteger(chunk?.wordCount)
+      ? chunk.wordCount
+      : text.split(/\s+/).filter(Boolean).length,
+    characterCount: Number.isSafeInteger(chunk?.characterCount)
+      ? chunk.characterCount
+      : text.length,
+    tokenEstimate: Number.isSafeInteger(chunk?.tokenEstimate)
+      ? chunk.tokenEstimate
+      : estimateTokens(text),
+    embeddingStatus: typeof chunk?.embeddingStatus === "string"
+      ? chunk.embeddingStatus
+      : "pending",
+    embeddingProvider: typeof chunk?.embeddingProvider === "string"
+      ? chunk.embeddingProvider
+      : "",
+    embeddingModel: typeof chunk?.embeddingModel === "string" ? chunk.embeddingModel : "",
+    retrievalRank: Number.isSafeInteger(chunk?.retrieval?.rank) ? chunk.retrieval.rank : null,
+    retrievalScore: Number.isFinite(chunk?.retrieval?.score) ? chunk.retrieval.score : null,
+    retrievalReason: typeof chunk?.retrieval?.reason === "string" ? chunk.retrieval.reason : "",
+    retrieval: chunk?.retrieval && typeof chunk.retrieval === "object"
+      ? {
+          rank: Number.isSafeInteger(chunk.retrieval.rank) ? chunk.retrieval.rank : null,
+          score: Number.isFinite(chunk.retrieval.score) ? chunk.retrieval.score : 0,
+          reason: typeof chunk.retrieval.reason === "string" ? chunk.retrieval.reason : "",
+        }
+      : null,
+    createdAt: timestamp,
+  };
 }
 
 function normalizePageInputs(pages = []) {

--- a/src/lib/data/schema.js
+++ b/src/lib/data/schema.js
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 
-export const DATA_MODEL_VERSION = 2;
+export const DATA_MODEL_VERSION = 3;
 
 export const SOURCE_KINDS = Object.freeze(["paste", "file", "pdf"]);
 export const DOCUMENT_STATUSES = Object.freeze([
@@ -115,6 +115,10 @@ export function createEmptyJsonStore() {
       },
       {
         id: "0004_document_processing_jobs",
+        appliedAt: nowIso(),
+      },
+      {
+        id: "0005_chunk_retrieval_metadata",
         appliedAt: nowIso(),
       },
     ],

--- a/src/lib/study/chunking.js
+++ b/src/lib/study/chunking.js
@@ -1,0 +1,352 @@
+import { estimateTokens } from "../data/schema.js";
+
+export const CHUNKING_LIMITS = Object.freeze({
+  minChunkChars: 240,
+  targetChunkChars: 760,
+  maxChunkChars: 980,
+  maxRetrievedChunks: 8,
+});
+
+const STOP_WORDS = new Set([
+  "about",
+  "after",
+  "again",
+  "against",
+  "almost",
+  "along",
+  "also",
+  "although",
+  "among",
+  "because",
+  "before",
+  "between",
+  "could",
+  "every",
+  "first",
+  "from",
+  "have",
+  "into",
+  "just",
+  "many",
+  "might",
+  "more",
+  "most",
+  "much",
+  "must",
+  "only",
+  "other",
+  "over",
+  "same",
+  "some",
+  "such",
+  "than",
+  "that",
+  "their",
+  "there",
+  "these",
+  "they",
+  "this",
+  "those",
+  "through",
+  "under",
+  "very",
+  "what",
+  "when",
+  "where",
+  "which",
+  "while",
+  "with",
+  "would",
+]);
+
+export function buildDocumentChunks(pages, options = {}) {
+  const limits = { ...CHUNKING_LIMITS, ...options };
+  const chunks = [];
+
+  for (const page of Array.isArray(pages) ? pages : []) {
+    const pageNumber = resolvePageNumber(page, chunks.length + 1);
+    const paragraphs = splitParagraphs(page?.text);
+    let sectionLabel = String(page?.citation || `Page ${pageNumber}`);
+    let buffer = null;
+
+    for (const paragraph of paragraphs) {
+      if (looksLikeSectionHeading(paragraph.text)) {
+        sectionLabel = trimText(paragraph.text.replace(/^[#\d.\s-]+/, ""), 80);
+      }
+
+      const paragraphPieces = splitOversizedParagraph(paragraph, limits.maxChunkChars);
+      for (const piece of paragraphPieces) {
+        if (!buffer) {
+          buffer = createChunkBuffer(piece, sectionLabel);
+          continue;
+        }
+
+        const combinedText = `${buffer.text}\n\n${piece.text}`;
+        const canMerge =
+          combinedText.length <= limits.targetChunkChars ||
+          buffer.text.length < limits.minChunkChars;
+
+        if (canMerge && piece.start === buffer.end + 1) {
+          buffer = {
+            ...buffer,
+            text: combinedText,
+            end: piece.end,
+            sectionLabel,
+          };
+          continue;
+        }
+
+        chunks.push(materializeChunk(buffer, chunks.length, pageNumber));
+        buffer = createChunkBuffer(piece, sectionLabel);
+      }
+    }
+
+    if (buffer) {
+      chunks.push(materializeChunk(buffer, chunks.length, pageNumber));
+    }
+  }
+
+  if (chunks.length) {
+    return chunks;
+  }
+
+  const fallbackText = (Array.isArray(pages) ? pages : [])
+    .map((page) => String(page?.text || ""))
+    .join("\n\n")
+    .trim();
+  return fallbackText
+    ? [
+        materializeChunk(
+          {
+            text: fallbackText,
+            start: 1,
+            end: 1,
+            sectionLabel: "Section 1",
+          },
+          0,
+          1,
+        ),
+      ]
+    : [];
+}
+
+export function selectRetrievalPassages(chunks, { title = "", goal = "", maxPassages } = {}) {
+  const candidates = Array.isArray(chunks) ? chunks : [];
+  const limit = Math.max(1, Number(maxPassages) || CHUNKING_LIMITS.maxRetrievedChunks);
+  if (candidates.length <= limit) {
+    return {
+      passages: candidates.map((chunk, index) => annotateRetrieval(chunk, {
+        rank: index + 1,
+        score: 1,
+        reason: "all_chunks_fit",
+      })),
+      stats: {
+        strategy: "all-chunks",
+        totalChunkCount: candidates.length,
+        retrievedChunkCount: candidates.length,
+        lowConfidence: false,
+      },
+    };
+  }
+
+  const queryTerms = extractTerms(`${title} ${goal}`);
+  const scored = candidates.map((chunk) => {
+    const chunkTerms = extractTerms([
+      chunk.text,
+      chunk.sectionLabel,
+      ...(Array.isArray(chunk.topics) ? chunk.topics : []),
+    ].join(" "));
+    const score = scoreChunk({ chunk, chunkTerms, queryTerms, totalChunks: candidates.length });
+
+    return { chunk, score };
+  });
+  const ranked = scored
+    .sort((left, right) => right.score - left.score || left.chunk.sequence - right.chunk.sequence)
+    .slice(0, limit);
+  const lowConfidence = !queryTerms.length || ranked.every((entry) => entry.score < 0.12);
+  const selected = lowConfidence
+    ? selectEvenly(candidates, limit).map((chunk, index) => ({
+        chunk,
+        score: 0,
+        rank: index + 1,
+        reason: "low_confidence_even_spread",
+      }))
+    : ranked.map((entry, index) => ({
+        ...entry,
+        rank: index + 1,
+        reason: "query_term_overlap",
+      }));
+
+  return {
+    passages: selected
+      .sort((left, right) => left.chunk.sequence - right.chunk.sequence)
+      .map((entry) => annotateRetrieval(entry.chunk, {
+        rank: entry.rank,
+        score: entry.score,
+        reason: entry.reason,
+      })),
+    stats: {
+      strategy: lowConfidence ? "even-spread-fallback" : "keyword-overlap",
+      totalChunkCount: candidates.length,
+      retrievedChunkCount: selected.length,
+      queryTermCount: queryTerms.length,
+      lowConfidence,
+    },
+  };
+}
+
+export function splitIntoSentences(text) {
+  return String(text || "")
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+}
+
+export function extractTopics(text) {
+  const counts = new Map();
+  for (const word of extractTerms(text)) {
+    counts.set(word, (counts.get(word) || 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, 3)
+    .map(([word]) => word.charAt(0).toUpperCase() + word.slice(1));
+}
+
+function splitParagraphs(text) {
+  const blocks = String(text || "")
+    .replace(/\r/g, "\n")
+    .split(/\n{2,}/)
+    .map((block) => block.replace(/[^\S\n]+/g, " ").trim())
+    .filter(Boolean);
+
+  return blocks.map((paragraph, index) => ({
+    text: paragraph,
+    start: index + 1,
+    end: index + 1,
+  }));
+}
+
+function splitOversizedParagraph(paragraph, maxChunkChars) {
+  if (paragraph.text.length <= maxChunkChars) {
+    return [paragraph];
+  }
+
+  const pieces = [];
+  let current = "";
+  for (const sentence of splitIntoSentences(paragraph.text)) {
+    const next = current ? `${current} ${sentence}` : sentence;
+    if (next.length > maxChunkChars && current) {
+      pieces.push({ ...paragraph, text: current.trim() });
+      current = sentence;
+      continue;
+    }
+    current = next;
+  }
+
+  if (current) {
+    pieces.push({ ...paragraph, text: current.trim() });
+  }
+
+  return pieces.length ? pieces : [paragraph];
+}
+
+function createChunkBuffer(piece, sectionLabel) {
+  return {
+    text: piece.text,
+    start: piece.start,
+    end: piece.end,
+    sectionLabel,
+  };
+}
+
+function materializeChunk(buffer, sequence, pageNumber) {
+  const text = buffer.text.trim();
+  const paragraphStart = buffer.start;
+  const paragraphEnd = buffer.end;
+  const citation = buildCitation({ pageNumber, paragraphStart, paragraphEnd });
+  const sentences = splitIntoSentences(text);
+
+  return {
+    sequence,
+    citation,
+    pageNumber,
+    sectionLabel: buffer.sectionLabel || `Page ${pageNumber}`,
+    paragraphStart,
+    paragraphEnd,
+    text,
+    sentences,
+    topics: extractTopics(text),
+    wordCount: text.split(/\s+/).filter(Boolean).length,
+    characterCount: text.length,
+    tokenEstimate: estimateTokens(text),
+  };
+}
+
+function buildCitation({ pageNumber, paragraphStart, paragraphEnd }) {
+  if (paragraphStart === paragraphEnd) {
+    return `Page ${pageNumber}, paragraph ${paragraphStart}`;
+  }
+  return `Page ${pageNumber}, paragraphs ${paragraphStart}-${paragraphEnd}`;
+}
+
+function scoreChunk({ chunk, chunkTerms, queryTerms, totalChunks }) {
+  if (!queryTerms.length || !chunkTerms.length) {
+    return 0;
+  }
+
+  const chunkTermSet = new Set(chunkTerms);
+  const overlap = queryTerms.filter((term) => chunkTermSet.has(term)).length;
+  const coverage = overlap / queryTerms.length;
+  const topicBoost = (Array.isArray(chunk.topics) ? chunk.topics : [])
+    .map((topic) => topic.toLowerCase())
+    .filter((topic) => queryTerms.includes(topic)).length * 0.08;
+  const positionBoost = Math.max(0, 1 - chunk.sequence / Math.max(totalChunks, 1)) * 0.04;
+
+  return coverage + topicBoost + positionBoost;
+}
+
+function extractTerms(text) {
+  return String(text || "")
+    .toLowerCase()
+    .match(/[a-z][a-z'-]{3,}/g)
+    ?.filter((word) => !STOP_WORDS.has(word)) || [];
+}
+
+function selectEvenly(chunks, limit) {
+  if (chunks.length <= limit) {
+    return chunks;
+  }
+
+  const selected = [];
+  const lastIndex = chunks.length - 1;
+  for (let index = 0; index < limit; index += 1) {
+    selected.push(chunks[Math.round((index * lastIndex) / Math.max(limit - 1, 1))]);
+  }
+  return [...new Map(selected.map((chunk) => [chunk.sequence, chunk])).values()];
+}
+
+function annotateRetrieval(chunk, retrieval) {
+  return {
+    ...chunk,
+    retrieval,
+  };
+}
+
+function resolvePageNumber(page, fallback) {
+  return Number.isSafeInteger(page?.pageNumber)
+    ? page.pageNumber
+    : Number.isSafeInteger(page?.num)
+      ? page.num
+      : fallback;
+}
+
+function looksLikeSectionHeading(text) {
+  const normalized = String(text || "").trim();
+  return normalized.length > 0 && normalized.length <= 90 && !/[.!?]$/.test(normalized);
+}
+
+function trimText(text, maxLength) {
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength - 1).trimEnd()}...`;
+}

--- a/src/lib/study/pipeline.js
+++ b/src/lib/study/pipeline.js
@@ -5,6 +5,10 @@ import {
   PDF_PARSE_STATUSES,
 } from "../documents/pdf-parser.js";
 import { DOCUMENT_JOB_SOURCE_TYPES } from "../jobs/document-processing.js";
+import {
+  buildDocumentChunks,
+  selectRetrievalPassages,
+} from "./chunking.js";
 
 const MAX_SOURCE_CHARS = 80_000;
 const MAX_PASSAGES = 8;
@@ -112,10 +116,20 @@ export async function runDocumentPipeline({
     diagnostics: extraction.diagnostics,
   });
 
-  const passages = createPassages(pages);
-  if (!passages.length) {
+  const chunks = buildDocumentChunks(pages);
+  if (!chunks.length) {
     throw new Error("The source did not produce enough readable passages to build cards.");
   }
+  const persistedChunks = await repository.saveDocumentChunks({
+    userId: user.id,
+    documentId,
+    chunks,
+  });
+  const retrieval = selectRetrievalPassages(persistedChunks, {
+    title: extraction.title || title,
+    goal,
+  });
+  const passages = retrieval.passages;
 
   const wordCount = sourceText.split(/\s+/).filter(Boolean).length;
   const baseDeck = {
@@ -124,7 +138,10 @@ export async function runDocumentPipeline({
     sourceKind: extraction.sourceKind,
     stats: {
       estimatedMinutes: Math.max(4, Math.round(wordCount / 180)),
-      chunkCount: passages.length,
+      chunkCount: chunks.length,
+      retrievedChunkCount: passages.length,
+      retrievalStrategy: retrieval.stats.strategy,
+      retrievalLowConfidence: retrieval.stats.lowConfidence,
       parseStatus: extraction.status,
       pageCount: extraction.diagnostics?.pageCount || pages.length,
       extractedWordCount: extraction.diagnostics?.wordCount || wordCount,

--- a/tests/retrieval-baseline-contract.test.mjs
+++ b/tests/retrieval-baseline-contract.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createLocalJsonStore } from "../src/lib/data/local-store.js";
+import { createStudyRepository } from "../src/lib/data/repositories.js";
+import {
+  buildDocumentChunks,
+  selectRetrievalPassages,
+} from "../src/lib/study/chunking.js";
+import {
+  createDocumentProcessingPayload,
+  DOCUMENT_PROCESSING_MAX_ATTEMPTS,
+  DOCUMENT_PROCESSING_QUEUE,
+} from "../src/lib/jobs/document-processing.js";
+import { processDocumentProcessingJob } from "../src/lib/jobs/document-processing-worker.js";
+
+test("Day 07 chunking preserves page, paragraph, order, and citation metadata", () => {
+  const chunks = buildDocumentChunks([
+    {
+      pageNumber: 1,
+      citation: "Page 1",
+      text: [
+        "Foundations",
+        "Retrieval practice starts when a learner reconstructs an idea before rereading it. The source wording remains available for verification after the attempt.",
+        "Grounded cards should carry compact excerpts and citations so answers can be checked without guessing.",
+      ].join("\n\n"),
+    },
+    {
+      pageNumber: 2,
+      citation: "Page 2",
+      text: [
+        "Chunk Metadata",
+        "Paragraph-aware chunking keeps source locations stable. A card can point to a page and paragraph range even when the generation prompt uses only selected chunks.",
+      ].join("\n\n"),
+    },
+  ]);
+
+  assert.ok(chunks.length >= 2);
+  assert.deepEqual(chunks.map((chunk) => chunk.sequence), chunks.map((_, index) => index));
+  assert.ok(chunks.every((chunk) => /^Page \d+, paragraph/.test(chunk.citation)));
+  assert.ok(chunks.every((chunk) => Number.isSafeInteger(chunk.pageNumber)));
+  assert.ok(chunks.every((chunk) => Number.isSafeInteger(chunk.paragraphStart)));
+  assert.ok(chunks.every((chunk) => Number.isSafeInteger(chunk.paragraphEnd)));
+  assert.ok(chunks.every((chunk) => chunk.paragraphEnd >= chunk.paragraphStart));
+  assert.ok(chunks.every((chunk) => chunk.tokenEstimate > 0));
+});
+
+test("Day 07 retrieval selects deterministic chunks and defines low-confidence fallback", () => {
+  const chunks = buildDocumentChunks([
+    {
+      pageNumber: 1,
+      text: buildParagraphs("general overview", 10),
+    },
+    {
+      pageNumber: 2,
+      text: buildParagraphs("retrieval calibration citation metadata", 10),
+    },
+  ]);
+
+  const focused = selectRetrievalPassages(chunks, {
+    title: "Grounded retrieval",
+    goal: "study retrieval calibration and citation metadata",
+    maxPassages: 4,
+  });
+  const fallback = selectRetrievalPassages(chunks, {
+    title: "",
+    goal: "",
+    maxPassages: 4,
+  });
+
+  assert.equal(focused.stats.strategy, "keyword-overlap");
+  assert.equal(focused.passages.length, 4);
+  assert.ok(focused.passages.every((chunk) => chunk.retrieval.reason === "query_term_overlap"));
+  assert.ok(
+    focused.passages.some((chunk) => /retrieval calibration citation metadata/i.test(chunk.text)),
+  );
+  assert.equal(fallback.stats.strategy, "even-spread-fallback");
+  assert.equal(fallback.stats.lowConfidence, true);
+  assert.equal(fallback.passages.length, 4);
+});
+
+test("repository worker persists all chunks and links generated cards to retrieved chunks", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "attention-regain-retrieval-"));
+  const store = createLocalJsonStore({ dataDir });
+  const repository = createStudyRepository({ store });
+
+  try {
+    const document = await repository.createDocumentRecord({
+      user: { id: "retrieval-user", email: "retrieval@example.com" },
+      title: "Large retrieval source",
+      goal: "study retrieval calibration and citation metadata",
+      sourceKind: "paste",
+      sourceRef: "inline://large-retrieval-source",
+    });
+    const job = await repository.enqueueDocumentProcessingJob({
+      userId: "retrieval-user",
+      documentId: document.id,
+      queueName: DOCUMENT_PROCESSING_QUEUE,
+      maxAttempts: DOCUMENT_PROCESSING_MAX_ATTEMPTS,
+      payload: createDocumentProcessingPayload({
+        documentId: document.id,
+        title: document.title,
+        goal: document.goal,
+        source: {
+          type: "inline_text",
+          sourceKind: "paste",
+          text: [
+            buildParagraphs("general learning overview", 12),
+            buildParagraphs("retrieval calibration citation metadata", 12),
+          ].join("\n\n"),
+        },
+      }),
+    });
+
+    const result = await processDocumentProcessingJob({
+      jobId: job.id,
+      repository,
+      env: { ENABLE_LIVE_GENERATION: "false" },
+    });
+    const raw = await store.read();
+    const workspace = await repository.getLatestWorkspaceForUser("retrieval-user");
+    const chunks = raw.documentChunks.filter((chunk) => chunk.documentId === document.id);
+    const selectedChunks = chunks.filter((chunk) => Number.isSafeInteger(chunk.retrievalRank));
+    const selectedChunkIds = new Set(selectedChunks.map((chunk) => chunk.id));
+
+    assert.equal(result.generationMode, "fallback");
+    assert.equal(workspace.document.status, "cards_generated");
+    assert.ok(chunks.length > workspace.deck.stats.retrievedChunkCount);
+    assert.equal(selectedChunks.length, workspace.deck.stats.retrievedChunkCount);
+    assert.ok(chunks.every((chunk) => /^Page \d+, paragraph/.test(chunk.citation)));
+    assert.ok(chunks.every((chunk) => Number.isSafeInteger(chunk.pageNumber)));
+    assert.ok(chunks.every((chunk) => chunk.sectionLabel));
+    assert.ok(workspace.deck.cards.length > 0);
+    assert.ok(workspace.deck.cards.every((card) => selectedChunkIds.has(card.chunkId)));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("Day 07 docs and migration describe chunk retrieval tuning", async () => {
+  const notes = await readFile(new URL("../docs/retrieval-baseline.md", import.meta.url), "utf8");
+  const migration = await readFile(
+    new URL("../db/migrations/0005_chunk_retrieval_metadata.sql", import.meta.url),
+    "utf8",
+  );
+
+  for (const expected of [
+    "paragraphStart",
+    "paragraphEnd",
+    "retrieval_rank",
+    "even spread",
+    "maxRetrievedChunks",
+  ]) {
+    assert.match(notes + migration, new RegExp(expected.replace(/[A-Z]/g, (letter) => letter)));
+  }
+});
+
+function buildParagraphs(topic, count) {
+  return Array.from({ length: count }, (_, index) => {
+    return [
+      `${topic} paragraph ${index + 1} explains how source-grounded study cards keep facts tied to the document.`,
+      "The learner should see enough context to recall the point while the app keeps citations precise and reviewable.",
+      "This paragraph is intentionally long enough to stand as a stable retrieval unit in contract tests.",
+    ].join(" ");
+  }).join("\n\n");
+}


### PR DESCRIPTION
## Day 07 — Complete and Ready for Review

Implemented and pushed branch `day-7/chunking-retrieval-baseline-20260424-2103`. Completed and closed GitHub child issues #41, #42, #43, #44, then closed parent #7 and milestone 8.

### Key Changes

- Added [chunking logic](/Users/work/Desktop/learning/Attention_regain/src/lib/study/chunking.js) for page/paragraph-aware chunks.
- Updated repository/pipeline persistence so full chunk sets are stored and cards link back to chunk IDs.
- Added migration [0005_chunk_retrieval_metadata.sql](/Users/work/Desktop/learning/Attention_regain/db/migrations/0005_chunk_retrieval_metadata.sql).
- Added retrieval docs and contract tests.

### Validation

Passed: preflight, `pnpm build`, `zsh scripts/lint.sh`, lockfile guard, `git diff --check`, and `node --test tests/*.test.mjs`. The AIAYN, SAM, and OPUS PDF fixtures all passed through upload, parsing, retrieval, grounded fallback generation, and feed retrieval.

### Status

No blockers.