### PR TITLE
Day 9/feed persistence resume flow 20260426 1921

### DIFF
--- a/db/migrations/0006_session_resume_state.sql
+++ b/db/migrations/0006_session_resume_state.sql
@@ -1,0 +1,11 @@
+-- Day 09 resume-state indexes.
+-- Existing timestamps carry last-active state; these indexes make resume lookup owner-scoped.
+
+CREATE INDEX IF NOT EXISTS study_sessions_user_updated_idx
+  ON study_sessions(user_id, updated_at DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS study_sessions_document_updated_idx
+  ON study_sessions(document_id, updated_at DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS study_interactions_session_card_created_idx
+  ON study_interactions(session_id, card_id, created_at DESC);

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -81,8 +81,9 @@ dead-letter state separately from the document row.
 ### study_sessions
 
 Represents one generated feed for one document and one goal. Sessions are owned
-by a user, carry the selected generation mode and model, and track readiness for
-the feed UI.
+by a user, carry the selected generation mode and model, track readiness for the
+feed UI, and use `updated_at` as the server-side last-active marker for resume
+lookup.
 
 ### study_cards
 
@@ -95,6 +96,10 @@ excerpt.
 Append-only interaction log for reveal, confidence, save, and dismiss events.
 This keeps learning actions out of browser-only storage and leaves room for
 later progress analytics.
+
+During resume, the repository folds the latest interaction events into
+`deck.feedback` so saved state, answer reveals, and confidence choices survive a
+page refresh or later visit.
 
 ## Status Transitions
 
@@ -172,6 +177,12 @@ Migration `0005_chunk_retrieval_metadata.sql` adds:
 - retrieval rank, score, and reason fields for selected generation chunks
 - indexes for page/paragraph and retrieval-ranked chunk lookups
 
+Migration `0006_session_resume_state.sql` adds:
+
+- owner-scoped session recency indexes for last-active resume lookup
+- document-scoped session recency indexes for ready feed restore
+- interaction indexes for rebuilding per-card feedback
+
 Rollout order:
 
 1. Create owner table and document tables.
@@ -184,6 +195,7 @@ Rollout order:
 8. Add parse outputs before background OCR and retrieval workers.
 9. Add background job rows before async worker orchestration ships.
 10. Add chunk retrieval metadata before grounded generation hardening.
+11. Add resume-state indexes before comeback-later feed loading ships.
 
 Rollback expectation: Day 03 migrations are reversible before production data is
 loaded. After real user data exists, rollback should be a forward migration that
@@ -210,6 +222,10 @@ Repository responsibilities:
 - Store documents, chunks, sessions, cards, and interactions.
 - Store extracted page text and parser diagnostics before generation.
 - Store background job payloads, attempts, and dead-letter state.
+- Select the last active document from document, session, and interaction
+  recency instead of browser-local feed memory.
+- Rebuild ready decks and per-card feedback from persisted cards and
+  interactions.
 - Return only rows owned by the authenticated user.
 - Keep local JSON storage and future Postgres storage behind the same service
   boundary.

--- a/docs/resume-flow.md
+++ b/docs/resume-flow.md
@@ -1,0 +1,41 @@
+# Resume Flow
+
+Day 09 makes the study workspace resumable from backend state instead of
+restoring generated feeds from browser storage.
+
+## Server Contract
+
+`GET /api/study-feed` returns one owner-scoped workspace:
+
+- `document`: the last active document for the authenticated user.
+- `job`: the latest processing job for that document, when one exists.
+- `deck`: the ready session, persisted cards, citations, and derived feedback.
+- `resume`: explicit entry metadata for the app shell.
+
+Last-active selection uses document activity, session activity, and interaction
+activity. A user who returns to an older ready feed and saves, reveals, or marks a
+card moves that session back to the front for the next visit.
+
+## Session State
+
+Generated cards are persisted in `study_cards`. Study actions are append-only
+`study_interactions` rows and are folded into `deck.feedback` during load:
+
+- `save_card` and `unsave_card` restore saved state.
+- `set_confidence` restores the latest confidence choice.
+- `reveal_answer` restores answer visibility for the current session.
+
+The browser may keep draft source text locally, but it does not store the active
+deck, document, or feedback as the source of truth.
+
+## Document Views
+
+The workspace renders distinct states from the same server response:
+
+- `ready`: persisted cards, source citations, and feedback are available.
+- `processing`: the document or job is queued, processing, parsed, or chunked.
+- `failed`: parsing or generation stopped and retry guidance is shown.
+- `empty`: no server-backed document exists yet.
+
+Retry actions use the stored job payload, so failed documents can be requeued
+without losing the original document linkage.

--- a/src/app/api/study-feed/route.js
+++ b/src/app/api/study-feed/route.js
@@ -197,7 +197,12 @@ export async function PATCH(request) {
       sessionId: String(payload.sessionId || ""),
       cardId: String(payload.cardId || ""),
       interactionType: String(payload.interactionType || ""),
-      value: typeof payload.value === "string" ? payload.value : JSON.stringify(payload.value ?? ""),
+      value:
+        payload.value == null
+          ? ""
+          : typeof payload.value === "string"
+            ? payload.value
+            : JSON.stringify(payload.value),
     });
 
     return Response.json({ interaction });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -207,6 +207,47 @@ textarea:focus-visible {
   color: #7b3320;
 }
 
+.resume-notice {
+  margin-top: 14px;
+  padding: 14px;
+  border-radius: 22px;
+  border: 1px solid rgba(41, 88, 70, 0.18);
+  background: rgba(41, 88, 70, 0.08);
+}
+
+.resume-notice.processing {
+  border-color: rgba(145, 93, 10, 0.22);
+  background: rgba(145, 93, 10, 0.08);
+}
+
+.resume-notice.failed {
+  border-color: rgba(120, 67, 58, 0.22);
+  background: rgba(120, 67, 58, 0.08);
+}
+
+.resume-notice strong,
+.resume-notice span {
+  display: block;
+}
+
+.resume-notice strong {
+  color: #2f513f;
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.resume-notice span {
+  margin-top: 8px;
+  color: #40372f;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.resume-notice p {
+  margin-top: 8px;
+}
+
 .form-grid {
   margin-top: 28px;
   display: grid;
@@ -561,6 +602,52 @@ textarea:focus-visible {
   color: #f8f0e4;
 }
 
+.document-strip {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  margin-top: 16px;
+  padding: 14px 16px;
+  border-radius: 22px;
+  border: 1px solid rgba(41, 88, 70, 0.22);
+  background: rgba(41, 88, 70, 0.16);
+}
+
+.document-strip.failed {
+  border-color: rgba(217, 108, 63, 0.24);
+  background: rgba(217, 108, 63, 0.12);
+}
+
+.document-strip strong,
+.document-strip span {
+  display: block;
+}
+
+.document-strip strong {
+  color: #f8f0e4;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.document-strip span {
+  margin-top: 7px;
+  color: #d1c2b2;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.document-strip em {
+  flex: 0 0 auto;
+  font-style: normal;
+  color: #efb08f;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
 .feed-body {
   flex: 1;
   overflow: auto;
@@ -583,6 +670,83 @@ textarea:focus-visible {
   padding: 22px;
   color: #1a1612;
   box-shadow: 0 18px 45px rgba(13, 11, 9, 0.14);
+}
+
+.state-panel {
+  min-height: calc(100vh - 110px);
+  display: grid;
+  align-content: center;
+  gap: 22px;
+  border-radius: 30px;
+  border: 1px solid rgba(23, 18, 15, 0.08);
+  background: #faf1e4;
+  padding: 28px;
+  color: #1a1612;
+  box-shadow: 0 18px 45px rgba(13, 11, 9, 0.14);
+}
+
+.state-panel.processing {
+  background: #fbf0dd;
+}
+
+.state-panel.failed {
+  background: #fbebe4;
+}
+
+.state-panel-head {
+  display: grid;
+  gap: 12px;
+}
+
+.state-panel h3 {
+  margin: 0;
+  max-width: 24ch;
+  font-family: var(--font-serif);
+  font-size: clamp(2rem, 5vw, 3.1rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.state-panel p {
+  margin: 0;
+  color: #4f453c;
+  line-height: 1.7;
+}
+
+.state-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.state-grid .metric {
+  min-width: 0;
+  border-color: rgba(23, 18, 15, 0.1);
+  background: rgba(255, 255, 255, 0.48);
+}
+
+.state-grid .metric label {
+  color: #76695d;
+}
+
+.state-grid .metric strong {
+  overflow-wrap: anywhere;
+  color: #241d18;
+  font-size: 1rem;
+}
+
+.state-copy {
+  display: grid;
+  gap: 12px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(23, 18, 15, 0.1);
+}
+
+.state-copy strong {
+  color: #241d18;
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
 }
 
 .feed-card-head {
@@ -802,6 +966,21 @@ textarea:focus-visible {
 
   .feed-card {
     padding: 18px;
+  }
+
+  .document-strip,
+  .state-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .document-strip {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .state-panel {
+    min-height: 58vh;
+    padding: 20px;
   }
 
   .metric {

--- a/src/components/study-workspace.js
+++ b/src/components/study-workspace.js
@@ -13,7 +13,7 @@ import { useAuthShell } from "./auth-shell-provider.js";
 import { PREVIEW_DECK, SAMPLE_SOURCE } from "../lib/study-preview.js";
 import { MAX_UPLOAD_BYTES, validateUploadDescriptor } from "../lib/uploads/validation.js";
 
-const STORAGE_KEY_PREFIX = "attention-regain-session-v3";
+const STORAGE_KEY_PREFIX = "attention-regain-draft-v4";
 
 const EMPTY_FEEDBACK = {
   confidence: null,
@@ -61,7 +61,7 @@ export function StudyWorkspace() {
     "The private workspace is ready. Upload a paper or paste notes to turn this session into a grounded study feed.",
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [hasLoadedStorage, setHasLoadedStorage] = useState(false);
+  const [hasLoadedDraft, setHasLoadedDraft] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   const deferredDeck = useDeferredValue(deck);
@@ -83,16 +83,10 @@ export function StudyWorkspace() {
       setSourceText(parsed.sourceText || "");
       setFileName(parsed.fileName || "");
       setUploadStatus(parsed.uploadStatus || null);
-      setWorkspaceState(parsed.workspaceState || null);
-      setDeck(parsed.deck || null);
-      setFeedback(parsed.feedback || {});
-      if (parsed.deck) {
-        setStatusMessage("Private study session restored from this browser.");
-      }
     } catch {
       window.localStorage.removeItem(storageKey);
     } finally {
-      setHasLoadedStorage(true);
+      setHasLoadedDraft(true);
     }
   }, [storageKey]);
 
@@ -114,7 +108,7 @@ export function StudyWorkspace() {
           setDeck(payload.deck || null);
           setWorkspaceState(payload);
           if (payload.deck) {
-            setFeedback({});
+            setFeedback(payload.deck.feedback || {});
           }
         });
         setTitle(payload.deck?.documentTitle || payload.document?.title || "");
@@ -131,7 +125,7 @@ export function StudyWorkspace() {
     };
   }, []);
 
-  const persistSession = useEffectEvent((nextDeck, nextFeedback) => {
+  const persistDraft = useEffectEvent(() => {
     window.localStorage.setItem(
       storageKey,
       JSON.stringify({
@@ -140,30 +134,24 @@ export function StudyWorkspace() {
         sourceText,
         fileName,
         uploadStatus,
-        workspaceState,
-        deck: nextDeck,
-        feedback: nextFeedback,
       }),
     );
   });
 
   useEffect(() => {
-    if (!hasLoadedStorage) {
+    if (!hasLoadedDraft) {
       return;
     }
-    persistSession(deck, feedback);
+    persistDraft();
   }, [
-    deck,
-    feedback,
     fileName,
     goal,
-    hasLoadedStorage,
-    persistSession,
+    hasLoadedDraft,
+    persistDraft,
     sourceText,
     storageKey,
     title,
     uploadStatus,
-    workspaceState,
   ]);
 
   const syncWorkspace = useEffectEvent(async () => {
@@ -178,7 +166,7 @@ export function StudyWorkspace() {
         setWorkspaceState(payload);
         setDeck(payload.deck || null);
         if (payload.deck) {
-          setFeedback({});
+          setFeedback(payload.deck.feedback || {});
         }
       });
       setStatusMessage(describeWorkspaceStatus(payload));
@@ -254,7 +242,7 @@ export function StudyWorkspace() {
         setWorkspaceState(payload);
         setDeck(payload.deck || null);
         if (payload.deck) {
-          setFeedback({});
+          setFeedback(payload.deck.feedback || {});
         }
       });
       setUploadStatus(buildProcessingBadge(payload));
@@ -296,6 +284,9 @@ export function StudyWorkspace() {
       startTransition(() => {
         setWorkspaceState(payload);
         setDeck(payload.deck || null);
+        if (payload.deck) {
+          setFeedback(payload.deck.feedback || {});
+        }
       });
       setUploadStatus(buildProcessingBadge(payload));
       setStatusMessage(describeWorkspaceStatus(payload));
@@ -507,6 +498,7 @@ export function StudyWorkspace() {
 
   const busy = isSubmitting || isPending;
   const visibleUploadStatus = buildProcessingBadge(workspaceState) || uploadStatus;
+  const workspaceView = resolveWorkspaceView(workspaceState, Boolean(visibleDeck && !isPreview));
 
   return (
     <main className="shell">
@@ -542,6 +534,18 @@ export function StudyWorkspace() {
             <p className="eyebrow">Session status</p>
             <p>{statusMessage}</p>
             {error ? <div className="error">{error}</div> : null}
+            {workspaceState?.resume?.available ? (
+              <div className={`resume-notice ${workspaceView.kind}`}>
+                <strong>{workspaceState.resume.label}</strong>
+                <span>
+                  {workspaceState.resume.documentTitle}
+                  {workspaceState.resume.lastActiveAt
+                    ? ` | ${formatResumeTime(workspaceState.resume.lastActiveAt)}`
+                    : ""}
+                </span>
+                <p>{workspaceState.resume.detail}</p>
+              </div>
+            ) : null}
             <p className="field-label" style={{ marginTop: 18 }}>
               Auth boundary
             </p>
@@ -707,6 +711,7 @@ export function StudyWorkspace() {
                   <Metric label="Saved" value={sessionStats.saved} />
                   <Metric label="Revealed" value={sessionStats.revealed} />
                 </div>
+                {!isPreview ? <DocumentStatusStrip workspaceState={workspaceState} /> : null}
               </header>
 
               <div className="feed-body">
@@ -788,48 +793,12 @@ export function StudyWorkspace() {
               </div>
             </>
           ) : (
-            <div className="feed-body">
-              <div className="feed-column">
-                <article className="feed-card">
-                  <div className="feed-card-head">
-                    <div>
-                      <span className="tone" style={TONE.application.style}>
-                        Background worker
-                      </span>
-                      <h3>{workspaceState?.document?.title || "Waiting for a study source"}</h3>
-                    </div>
-                  </div>
-                  <p>{describeWorkspaceStatus(workspaceState)}</p>
-                  <div className="card-prompt">
-                    <strong>Current document status</strong>
-                    <p>
-                      {workspaceState?.document?.status
-                        ? formatDocumentStatus(workspaceState.document.status)
-                        : "No server-backed document is active yet."}
-                    </p>
-                    {workspaceState?.job ? (
-                      <p>
-                        Attempt {workspaceState.job.attemptCount} of {workspaceState.job.maxAttempts}.
-                      </p>
-                    ) : null}
-                    {workspaceState?.document?.failureReason ? (
-                      <p>{workspaceState.document.failureReason}</p>
-                    ) : null}
-                    {isRecoverableWorkspace(workspaceState) ? (
-                      <button
-                        className="primary-button"
-                        disabled={busy}
-                        onClick={handleRetryProcessing}
-                        style={{ marginTop: 14 }}
-                        type="button"
-                      >
-                        {busy ? "Retrying..." : "Retry generation"}
-                      </button>
-                    ) : null}
-                  </div>
-                </article>
-              </div>
-            </div>
+            <DocumentStatePanel
+              busy={busy}
+              onRetry={handleRetryProcessing}
+              workspaceState={workspaceState}
+              workspaceView={workspaceView}
+            />
           )}
         </div>
       </section>
@@ -842,6 +811,64 @@ function Metric({ label, value }) {
     <div className="metric">
       <label>{label}</label>
       <strong>{value}</strong>
+    </div>
+  );
+}
+
+function DocumentStatusStrip({ workspaceState }) {
+  const view = resolveWorkspaceView(workspaceState, Boolean(workspaceState?.deck));
+
+  return (
+    <div className={`document-strip ${view.kind}`}>
+      <div>
+        <strong>{view.label}</strong>
+        <span>{view.detail}</span>
+      </div>
+      <em>{formatDocumentStatus(workspaceState?.document?.status || "cards_generated")}</em>
+    </div>
+  );
+}
+
+function DocumentStatePanel({ busy, onRetry, workspaceState, workspaceView }) {
+  const document = workspaceState?.document;
+  const job = workspaceState?.job;
+
+  return (
+    <div className="feed-body">
+      <div className="feed-column">
+        <article className={`state-panel ${workspaceView.kind}`}>
+          <div className="state-panel-head">
+            <span className="tone" style={workspaceView.tone}>
+              {workspaceView.badge}
+            </span>
+            <h3>{document?.title || "Waiting for a study source"}</h3>
+            <p>{workspaceView.detail}</p>
+          </div>
+
+          <div className="state-grid">
+            <Metric label="Document" value={formatDocumentStatus(document?.status || "None")} />
+            <Metric label="Worker" value={formatDocumentStatus(job?.status || "Idle")} />
+            <Metric label="Attempts" value={job ? `${job.attemptCount}/${job.maxAttempts}` : "0/0"} />
+          </div>
+
+          <div className="state-copy">
+            <strong>{workspaceView.label}</strong>
+            <p>{describeWorkspaceStatus(workspaceState)}</p>
+            {document?.failureReason ? <p>{document.failureReason}</p> : null}
+            {job?.lastError ? <p>{job.lastError}</p> : null}
+            {isRecoverableWorkspace(workspaceState) ? (
+              <button
+                className="primary-button"
+                disabled={busy}
+                onClick={onRetry}
+                type="button"
+              >
+                {busy ? "Retrying..." : "Retry generation"}
+              </button>
+            ) : null}
+          </div>
+        </article>
+      </div>
     </div>
   );
 }
@@ -903,6 +930,61 @@ function describeWorkspaceStatus(workspaceState) {
   }
 
   return "The private study workspace is ready.";
+}
+
+function resolveWorkspaceView(workspaceState, hasReadyDeck = false) {
+  const status = workspaceState?.document?.status;
+  if (hasReadyDeck || workspaceState?.deck || status === "cards_generated") {
+    return {
+      kind: "ready",
+      badge: "Ready",
+      label: "Server-backed feed ready",
+      detail: "Cards, citations, and study actions are loaded from persisted state.",
+      tone: TONE.recall.style,
+    };
+  }
+
+  if (status === "failed" || status === "parse_failed" || status === "ocr_needed") {
+    return {
+      kind: "failed",
+      badge: "Needs action",
+      label: "Processing stopped",
+      detail: "The document is saved, but cards are not ready. Retry when the source or parser path is available.",
+      tone: TONE.pitfall.style,
+    };
+  }
+
+  if (status) {
+    return {
+      kind: "processing",
+      badge: "Processing",
+      label: "Document is not ready yet",
+      detail: "The background worker owns parsing, retrieval prep, and grounded card generation.",
+      tone: TONE.application.style,
+    };
+  }
+
+  return {
+    kind: "empty",
+    badge: "No document",
+    label: "No active document",
+    detail: "Add a source to create a resumable server-backed feed.",
+    tone: TONE.glance.style,
+  };
+}
+
+function formatResumeTime(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "recent activity";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
 }
 
 function formatDocumentStatus(status) {

--- a/src/lib/data/repositories.js
+++ b/src/lib/data/repositories.js
@@ -840,7 +840,7 @@ async function getLatestDeckForUser(store, userId) {
   const current = await store.read();
   const session = current.studySessions
     .filter((entry) => entry.userId === ownerId && entry.status === "ready")
-    .sort((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)))[0];
+    .sort((left, right) => compareRecentRows(left, right))[0];
 
   if (!session) {
     return null;
@@ -850,19 +850,20 @@ async function getLatestDeckForUser(store, userId) {
   const cards = current.studyCards
     .filter((entry) => entry.sessionId === session.id)
     .sort((left, right) => left.sequence - right.sequence);
+  const interactions = current.studyInteractions
+    .filter((entry) => entry.sessionId === session.id && entry.userId === ownerId)
+    .sort((left, right) => String(left.createdAt).localeCompare(String(right.createdAt)));
 
-  return buildDeckResponse({ document, session, cards });
+  return buildDeckResponse({ document, session, cards, interactions });
 }
 
 async function getLatestWorkspaceForUser(store, userId) {
   const ownerId = requireNonEmpty(userId, "userId");
   const current = await store.read();
-  const document = current.documents
-    .filter((entry) => entry.userId === ownerId)
-    .sort((left, right) => String(right.updatedAt).localeCompare(String(left.updatedAt)))[0];
+  const { document, lastActiveAt } = selectLastActiveDocument(current, ownerId);
 
   if (!document) {
-    return { document: null, job: null, deck: null };
+    return { document: null, job: null, deck: null, resume: buildResumeResponse({}) };
   }
 
   const job = current.documentJobs
@@ -870,17 +871,32 @@ async function getLatestWorkspaceForUser(store, userId) {
     .sort((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)))[0] || null;
   const session = current.studySessions
     .filter((entry) => entry.documentId === document.id && entry.userId === ownerId)
-    .sort((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)))[0] || null;
+    .sort((left, right) => compareRecentRows(left, right))[0] || null;
   const cards = session?.status === "ready"
     ? current.studyCards
       .filter((entry) => entry.sessionId === session.id)
       .sort((left, right) => left.sequence - right.sequence)
     : [];
+  const interactions = session
+    ? current.studyInteractions
+      .filter((entry) => entry.sessionId === session.id && entry.userId === ownerId)
+      .sort((left, right) => String(left.createdAt).localeCompare(String(right.createdAt)))
+    : [];
+  const deck = session?.status === "ready"
+    ? buildDeckResponse({ document, session, cards, interactions })
+    : null;
 
   return {
     document: buildDocumentResponse(document),
     job: buildJobResponse(job),
-    deck: session?.status === "ready" ? buildDeckResponse({ document, session, cards }) : null,
+    deck,
+    resume: buildResumeResponse({
+      document,
+      job,
+      session,
+      deck,
+      lastActiveAt,
+    }),
   };
 }
 
@@ -920,6 +936,14 @@ async function recordInteraction(store, input) {
     return {
       ...current,
       studyCards: updateCardStatus(current.studyCards, interaction),
+      studySessions: current.studySessions.map((entry) =>
+        entry.id === session.id
+          ? { ...entry, updatedAt: timestamp }
+          : entry),
+      documents: current.documents.map((entry) =>
+        entry.id === session.documentId && entry.userId === userId
+          ? { ...entry, updatedAt: timestamp }
+          : entry),
       studyInteractions: [...current.studyInteractions, interaction],
     };
   });
@@ -927,7 +951,7 @@ async function recordInteraction(store, input) {
   return interaction;
 }
 
-function buildDeckResponse({ document, session, cards }) {
+function buildDeckResponse({ document, session, cards, interactions = [] }) {
   return {
     documentId: document?.id || "",
     sessionId: session.id,
@@ -948,15 +972,19 @@ function buildDeckResponse({ document, session, cards }) {
       sourceReference: card.sourceReference || undefined,
       status: card.status,
     })),
+    feedback: buildFeedbackResponse({ cards, interactions }),
     generationMode: session.generationMode,
     model: session.model,
     stats: {
       ...(session.stats || {}),
       cardCount: cards.length,
     },
+    readyAt: session.readyAt || session.createdAt,
+    lastActiveAt: session.updatedAt || session.readyAt || session.createdAt,
     persistence: {
       adapter: "local-json",
       serverStored: true,
+      resumeSource: "server",
     },
   };
 }
@@ -978,6 +1006,48 @@ function buildDocumentResponse(document) {
     updatedAt: document.updatedAt,
     failedAt: document.failedAt,
     failureReason: document.failureReason || "",
+    statusGroup: groupDocumentStatus(document.status),
+  };
+}
+
+function buildResumeResponse({ document = null, job = null, session = null, deck = null, lastActiveAt = "" }) {
+  if (!document) {
+    return {
+      available: false,
+      status: "empty",
+      label: "No resumable document",
+      detail: "Add a source to create the first server-backed study session.",
+    };
+  }
+
+  const statusGroup = deck ? "ready" : groupDocumentStatus(document.status);
+  const labels = {
+    ready: "Resume ready feed",
+    processing: "Resume processing document",
+    failed: "Review failed document",
+    empty: "No resumable document",
+  };
+  const details = {
+    ready: "Cards and study actions were loaded from the backend.",
+    processing: "The worker state is still active; this view will refresh while it runs.",
+    failed: document.failureReason || job?.lastError || "Processing stopped before cards were ready.",
+    empty: "Add a source to create the first server-backed study session.",
+  };
+
+  return {
+    available: true,
+    status: statusGroup,
+    label: labels[statusGroup] || labels.processing,
+    detail: details[statusGroup] || details.processing,
+    documentId: document.id,
+    documentTitle: document.title,
+    sessionId: session?.id || "",
+    lastActiveAt:
+      lastActiveAt ||
+      session?.updatedAt ||
+      session?.readyAt ||
+      session?.createdAt ||
+      document.updatedAt,
   };
 }
 
@@ -1002,6 +1072,109 @@ function buildJobResponse(job) {
     lastErrorCode: job.lastErrorCode || "",
     resultStatus: job.resultStatus || "",
   };
+}
+
+function buildFeedbackResponse({ cards, interactions }) {
+  const feedback = Object.fromEntries(
+    cards.map((card) => [
+      card.id,
+      {
+        confidence: null,
+        saved: card.status === "saved",
+        revealed: false,
+      },
+    ]),
+  );
+
+  for (const interaction of interactions) {
+    if (!interaction.cardId || !feedback[interaction.cardId]) {
+      continue;
+    }
+
+    if (interaction.interactionType === "save_card") {
+      feedback[interaction.cardId].saved = true;
+    } else if (interaction.interactionType === "unsave_card") {
+      feedback[interaction.cardId].saved = false;
+    } else if (interaction.interactionType === "reveal_answer") {
+      feedback[interaction.cardId].revealed = interaction.value !== "false";
+    } else if (interaction.interactionType === "set_confidence") {
+      feedback[interaction.cardId].confidence = interaction.value || null;
+    }
+  }
+
+  return feedback;
+}
+
+function selectLastActiveDocument(current, ownerId) {
+  const sessionsByDocumentId = new Map();
+  for (const session of current.studySessions.filter((entry) => entry.userId === ownerId)) {
+    const currentSession = sessionsByDocumentId.get(session.documentId);
+    if (!currentSession || compareRecentRows(session, currentSession) < 0) {
+      sessionsByDocumentId.set(session.documentId, session);
+    }
+  }
+
+  const interactionTimesBySessionId = new Map();
+  for (const interaction of current.studyInteractions.filter((entry) => entry.userId === ownerId)) {
+    const previous = interactionTimesBySessionId.get(interaction.sessionId) || "";
+    if (String(interaction.createdAt).localeCompare(previous) > 0) {
+      interactionTimesBySessionId.set(interaction.sessionId, interaction.createdAt);
+    }
+  }
+
+  const ranked = current.documents
+    .filter((entry) => entry.userId === ownerId)
+    .map((document) => {
+      const session = sessionsByDocumentId.get(document.id);
+      const interactionAt = session ? interactionTimesBySessionId.get(session.id) : "";
+      const lastActiveAt = maxIso([
+        document.updatedAt,
+        document.createdAt,
+        session?.updatedAt,
+        session?.readyAt,
+        session?.createdAt,
+        interactionAt,
+      ]);
+      return { document, lastActiveAt };
+    })
+    .sort((left, right) => {
+      const activeComparison = String(right.lastActiveAt).localeCompare(String(left.lastActiveAt));
+      if (activeComparison !== 0) {
+        return activeComparison;
+      }
+      return String(right.document.createdAt).localeCompare(String(left.document.createdAt));
+    });
+
+  return ranked[0] || { document: null, lastActiveAt: "" };
+}
+
+function compareRecentRows(left, right) {
+  const updatedComparison = String(right.updatedAt || right.createdAt)
+    .localeCompare(String(left.updatedAt || left.createdAt));
+  if (updatedComparison !== 0) {
+    return updatedComparison;
+  }
+  return String(right.createdAt).localeCompare(String(left.createdAt));
+}
+
+function maxIso(values) {
+  return values
+    .filter(Boolean)
+    .map(String)
+    .sort((left, right) => right.localeCompare(left))[0] || "";
+}
+
+function groupDocumentStatus(status) {
+  if (status === "cards_generated") {
+    return "ready";
+  }
+  if (status === "failed" || status === "parse_failed" || status === "ocr_needed") {
+    return "failed";
+  }
+  if (!status) {
+    return "empty";
+  }
+  return "processing";
 }
 
 function updateCardStatus(cards, interaction) {

--- a/src/lib/data/schema.js
+++ b/src/lib/data/schema.js
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 
-export const DATA_MODEL_VERSION = 3;
+export const DATA_MODEL_VERSION = 4;
 
 export const SOURCE_KINDS = Object.freeze(["paste", "file", "pdf"]);
 export const DOCUMENT_STATUSES = Object.freeze([
@@ -119,6 +119,10 @@ export function createEmptyJsonStore() {
       },
       {
         id: "0005_chunk_retrieval_metadata",
+        appliedAt: nowIso(),
+      },
+      {
+        id: "0006_session_resume_state",
         appliedAt: nowIso(),
       },
     ],

--- a/tests/resume-flow-contract.test.mjs
+++ b/tests/resume-flow-contract.test.mjs
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createAuthenticatedProductSession,
+  serializeProductSession,
+} from "../src/lib/auth/session-shared.js";
+import { createLocalJsonStore } from "../src/lib/data/local-store.js";
+import { createStudyRepository } from "../src/lib/data/repositories.js";
+import {
+  createDocumentProcessingPayload,
+  DOCUMENT_PROCESSING_QUEUE,
+} from "../src/lib/jobs/document-processing.js";
+
+test("Day 09 resume docs and migration define persisted comeback state", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const doc = await readFile(new URL("../docs/resume-flow.md", import.meta.url), "utf8");
+  const migration = await readFile(
+    new URL("../db/migrations/0006_session_resume_state.sql", import.meta.url),
+    "utf8",
+  );
+
+  for (const expected of [
+    "GET /api/study-feed",
+    "last active document",
+    "deck.feedback",
+    "ready",
+    "processing",
+    "failed",
+  ]) {
+    assert.match(doc, new RegExp(expected));
+  }
+
+  assert.match(migration, /study_sessions_user_updated_idx/);
+  assert.match(migration, /study_interactions_session_card_created_idx/);
+});
+
+test("repository restores the last active ready session with persisted feedback", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "attention-regain-resume-"));
+  const repository = createStudyRepository({
+    store: createLocalJsonStore({ dataDir }),
+  });
+
+  try {
+    const firstDeck = await repository.saveGeneratedDeck(buildDeckInput({
+      userId: "resume-user",
+      documentTitle: "Earlier source",
+      citation: "Page 1",
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await repository.saveGeneratedDeck(buildDeckInput({
+      userId: "resume-user",
+      documentTitle: "Later source",
+      citation: "Page 2",
+    }));
+
+    let workspace = await repository.getLatestWorkspaceForUser("resume-user");
+    assert.equal(workspace.deck.documentTitle, "Later source");
+    assert.equal(workspace.resume.status, "ready");
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await repository.recordInteraction({
+      userId: "resume-user",
+      sessionId: firstDeck.sessionId,
+      cardId: firstDeck.cards[0].id,
+      interactionType: "save_card",
+      value: "true",
+    });
+    await repository.recordInteraction({
+      userId: "resume-user",
+      sessionId: firstDeck.sessionId,
+      cardId: firstDeck.cards[0].id,
+      interactionType: "set_confidence",
+      value: "locked",
+    });
+    await repository.recordInteraction({
+      userId: "resume-user",
+      sessionId: firstDeck.sessionId,
+      cardId: firstDeck.cards[0].id,
+      interactionType: "reveal_answer",
+      value: "true",
+    });
+
+    workspace = await repository.getLatestWorkspaceForUser("resume-user");
+    const feedback = workspace.deck.feedback[firstDeck.cards[0].id];
+
+    assert.equal(workspace.deck.documentTitle, "Earlier source");
+    assert.equal(workspace.resume.documentId, firstDeck.documentId);
+    assert.equal(workspace.resume.label, "Resume ready feed");
+    assert.equal(feedback.saved, true);
+    assert.equal(feedback.confidence, "locked");
+    assert.equal(feedback.revealed, true);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("study feed GET restores server state after a refresh-like route load", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "attention-regain-route-resume-"));
+  const previousDataDir = process.env.ATTENTION_REGAIN_DATA_DIR;
+  process.env.ATTENTION_REGAIN_DATA_DIR = dataDir;
+
+  try {
+    const { POST, GET, PATCH } = await import("../src/app/api/study-feed/route.js");
+    const sessionCookie = serializeProductSession(
+      createAuthenticatedProductSession({
+        userId: "route-resume-user",
+        email: "reader@example.com",
+        displayName: "Resume Reader",
+        source: "test",
+      }),
+    );
+    const formData = new FormData();
+    formData.set("title", "Route resume source");
+    formData.set("goal", "validate persisted resume loading");
+    formData.set(
+      "sourceText",
+      "Server backed resume state should survive refreshes. ".repeat(24),
+    );
+
+    const response = await POST(
+      new Request("http://localhost/api/study-feed", {
+        method: "POST",
+        body: formData,
+        headers: {
+          cookie: `attention_regain_session=${sessionCookie}`,
+        },
+      }),
+    );
+    const accepted = await response.json();
+    assert.equal(response.status, 202);
+
+    const { processDocumentProcessingJob } = await import(
+      "../src/lib/jobs/document-processing-worker.js"
+    );
+    await processDocumentProcessingJob({ jobId: accepted.job.id });
+
+    const readyResponse = await GET(
+      new Request("http://localhost/api/study-feed", {
+        method: "GET",
+        headers: {
+          cookie: `attention_regain_session=${sessionCookie}`,
+        },
+      }),
+    );
+    const ready = await readyResponse.json();
+    assert.equal(readyResponse.status, 200);
+    assert.equal(ready.resume.status, "ready");
+    assert.equal(ready.deck.persistence.resumeSource, "server");
+
+    const patchResponse = await PATCH(
+      new Request("http://localhost/api/study-feed", {
+        method: "PATCH",
+        body: JSON.stringify({
+          sessionId: ready.deck.sessionId,
+          cardId: ready.deck.cards[0].id,
+          interactionType: "set_confidence",
+          value: "review",
+        }),
+        headers: {
+          "content-type": "application/json",
+          cookie: `attention_regain_session=${sessionCookie}`,
+        },
+      }),
+    );
+    assert.equal(patchResponse.status, 200);
+
+    const resumedResponse = await GET(
+      new Request("http://localhost/api/study-feed", {
+        method: "GET",
+        headers: {
+          cookie: `attention_regain_session=${sessionCookie}`,
+        },
+      }),
+    );
+    const resumed = await resumedResponse.json();
+
+    assert.equal(resumed.deck.feedback[ready.deck.cards[0].id].confidence, "review");
+    assert.equal(resumed.resume.label, "Resume ready feed");
+  } finally {
+    if (typeof previousDataDir === "string") {
+      process.env.ATTENTION_REGAIN_DATA_DIR = previousDataDir;
+    } else {
+      delete process.env.ATTENTION_REGAIN_DATA_DIR;
+    }
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("repository exposes distinct processing and failed resume states", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "attention-regain-state-"));
+  const repository = createStudyRepository({
+    store: createLocalJsonStore({ dataDir }),
+  });
+
+  try {
+    const document = await repository.createDocumentRecord({
+      user: { id: "state-user" },
+      title: "Queued source",
+      goal: "inspect state views",
+      sourceKind: "paste",
+      sourceRef: "inline://state-source",
+    });
+    const job = await repository.enqueueDocumentProcessingJob({
+      userId: "state-user",
+      documentId: document.id,
+      queueName: DOCUMENT_PROCESSING_QUEUE,
+      maxAttempts: 1,
+      payload: createDocumentProcessingPayload({
+        documentId: document.id,
+        title: document.title,
+        goal: document.goal,
+        source: {
+          type: "inline_text",
+          sourceKind: "paste",
+          text: "A queued document keeps processing visible before cards exist.",
+        },
+      }),
+    });
+
+    let workspace = await repository.getLatestWorkspaceForUser("state-user");
+    assert.equal(workspace.resume.status, "processing");
+    assert.equal(workspace.deck, null);
+
+    await repository.claimDocumentProcessingJob({ jobId: job.id, workerId: "test-worker" });
+    await repository.failDocumentProcessingJob({
+      jobId: job.id,
+      errorMessage: "Generation failed permanently.",
+      retryDelayMs: 250,
+    });
+
+    workspace = await repository.getLatestWorkspaceForUser("state-user");
+    assert.equal(workspace.document.status, "failed");
+    assert.equal(workspace.resume.status, "failed");
+    assert.match(workspace.resume.detail, /Generation failed permanently/);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+function buildDeckInput({ userId, documentTitle, citation }) {
+  const passage = `${documentTitle} explains that durable sessions let a learner leave and return without losing grounded study cards.`;
+
+  return {
+    user: { id: userId, email: "reader@example.com", displayName: "Reader" },
+    documentTitle,
+    goal: "resume the previous study context",
+    sourceKind: "pdf",
+    sourceRef: `${documentTitle}.pdf`,
+    passages: [
+      {
+        text: passage,
+        citation,
+        topics: ["Resume"],
+      },
+    ],
+    focusTags: ["Resume"],
+    generationMode: "fallback",
+    model: "heuristic-fallback",
+    stats: { cardCount: 1, chunkCount: 1 },
+    cards: [
+      {
+        kind: "recall",
+        title: "Resume without losing state",
+        body: "The card is grounded in the persisted source passage.",
+        question: "What should a durable session preserve?",
+        answer: "Grounded study cards and learning actions.",
+        excerpt: passage,
+        citation,
+      },
+    ],
+  };
+}


### PR DESCRIPTION
# Day 09 — Complete and Ready for Review

Implemented and pushed `origin/day-9/feed-persistence-resume-flow-20260426-1921`.

The work covers **#49–#52**: server-backed resume metadata, last-active document/session restore, persisted feedback reconstruction, explicit ready/processing/failed/empty document UI, Day 09 migration, docs, and resume-flow contract tests.

## Validation Passed

- Preflight
- `pnpm build`
- `node --test tests/*.test.mjs`
- AIAYN, SAM, and OPUS fixture flows
- Lockfile guard
- `git diff --check`
- Browser resume/save/reload check via in-app DevTools browser

## GitHub State

GitHub state is updated: child issues **#49–#52** closed, parent **#9** closed, milestone **#10** closed.

## Environment Note

Terminal Playwright CLI was blocked by local npm/Chrome cache permissions, so the in-app browser was used for visual validation. The temporary Next server on port `3030` is still listening as PID `25944`; this sandbox rejected `kill` with `Operation not permitted`.